### PR TITLE
Add Changelog Fragment creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # elastic-agent-changelog-tool
 Tooling to manage the changelog for beats, Elastic Agent and Fleet Server
+
+## Requirements
+
+`git` CLI should be installed and available.

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -7,11 +7,11 @@ package cmd
 
 import (
 	"errors"
-	"os"
 
 	"github.com/elastic/elastic-agent-changelog-tool/internal/changelog/fragment"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var errNewCmdMissingArg = errors.New("new requires title argument")
@@ -29,16 +29,10 @@ func NewCmd() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			title := args[0]
+			location := viper.GetString("fragment_location")
+			fc := fragment.NewCreator(afero.NewOsFs(), location)
 
-			// TODO: this should be a meaningful location
-			location, err := os.Getwd()
-			if err != nil {
-				return err
-			}
-
-			fc := fragment.NewCreator(afero.NewOsFs())
-
-			if err := fc.Create(location, title); err != nil {
+			if err := fc.Create(title); err != nil {
 				return err
 			}
 

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -1,0 +1,50 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+
+package cmd
+
+import (
+	"errors"
+	"os"
+
+	"github.com/elastic/elastic-agent-changelog-tool/internal/changelog/fragment"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+var errNewCmdMissingArg = errors.New("new requires title argument")
+
+func NewCmd() *cobra.Command {
+
+	newCmd := &cobra.Command{
+		Use:  "new title",
+		Long: "Create a new changelog fragment",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errNewCmdMissingArg
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			title := args[0]
+
+			// TODO: this should be a meaningful location
+			location, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+
+			fc := fragment.NewCreator(afero.NewOsFs())
+
+			if err := fc.Create(location, title); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	return newCmd
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 
 require (
@@ -36,5 +37,4 @@ require (
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/internal/changelog/fragment/creator.go
+++ b/internal/changelog/fragment/creator.go
@@ -1,0 +1,80 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package fragment
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/afero"
+	"gopkg.in/yaml.v3"
+)
+
+// timestamp represent a function providing a timestamp.
+// It's used to allow replacing the value with a known one during testing.
+type timestamp func() int64
+
+func NewCreator(fs afero.Fs) FragmentCreator {
+	return FragmentCreator{
+		fs:        fs,
+		timestamp: time.Now().Unix,
+	}
+}
+
+// TestNewCreator sets up a FragmentCreator configured to be used in testing.
+func TestNewCreator() FragmentCreator {
+	f := NewCreator(afero.NewMemMapFs())
+	f.timestamp = func() int64 { return 1647345675 }
+	return f
+}
+
+type FragmentCreator struct {
+	fs afero.Fs
+	// timestamp allow overriding value in tests
+	timestamp timestamp
+}
+
+// filename computes the filename for the changelog fragment to be created.
+// To provide unique names the provided slug is prepended with current timestamp.
+func (f FragmentCreator) filename(slug string) string {
+	filename := fmt.Sprintf("%d-%s.yaml", f.timestamp(), sanitizeFilename(slug))
+	return filename
+}
+
+// Create marshal changelog fragment and persist it to file.
+func (c FragmentCreator) Create(slug string) error {
+	frg := Fragment{}
+
+	data, err := yaml.Marshal(&frg)
+	if err != nil {
+		return err
+	}
+
+	return afero.WriteFile(c.fs, c.filename(slug), data, 0660)
+}
+
+// sanitizeFilename takes care of removing dangerous elements from a string so it can be safely
+// used as a filename.
+// NOTE: does not prevent command injection or ensure complete escaping of input
+func sanitizeFilename(s string) string {
+	s = strings.Replace(s, " ", "-", -1)
+	s = strings.Replace(s, "/", "-", -1)
+	s = strings.Replace(s, "\\", "-", -1)
+	return s
+}

--- a/internal/changelog/fragment/creator.go
+++ b/internal/changelog/fragment/creator.go
@@ -1,19 +1,6 @@
-// Licensed to Elasticsearch B.V. under one or more contributor
-// license agreements. See the NOTICE file distributed with
-// this work for additional information regarding copyright
-// ownership. Elasticsearch B.V. licenses this file to you under
-// the Apache License, Version 2.0 (the "License"); you may
-// not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package fragment
 

--- a/internal/changelog/fragment/creator.go
+++ b/internal/changelog/fragment/creator.go
@@ -19,6 +19,7 @@ package fragment
 
 import (
 	"fmt"
+	"path"
 	"strings"
 	"time"
 
@@ -58,7 +59,7 @@ func (f FragmentCreator) filename(slug string) string {
 }
 
 // Create marshal changelog fragment and persist it to file.
-func (c FragmentCreator) Create(slug string) error {
+func (c FragmentCreator) Create(location, slug string) error {
 	frg := Fragment{}
 
 	data, err := yaml.Marshal(&frg)
@@ -66,7 +67,7 @@ func (c FragmentCreator) Create(slug string) error {
 		return err
 	}
 
-	return afero.WriteFile(c.fs, c.filename(slug), data, 0660)
+	return afero.WriteFile(c.fs, path.Join(location, c.filename(slug)), data, 0660)
 }
 
 // sanitizeFilename takes care of removing dangerous elements from a string so it can be safely

--- a/internal/changelog/fragment/creator_internal_test.go
+++ b/internal/changelog/fragment/creator_internal_test.go
@@ -18,6 +18,7 @@
 package fragment
 
 import (
+	"path"
 	"reflect"
 	"testing"
 
@@ -58,10 +59,11 @@ func TestSanitizeFilename(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	fc := TestNewCreator()
+	location := afero.GetTempDir(fc.fs, "testdata")
 
-	fc.Create("foobar")
+	fc.Create(location, "foobar")
 
-	content, err := afero.ReadFile(fc.fs, fc.filename("foobar"))
+	content, err := afero.ReadFile(fc.fs, path.Join(location, fc.filename("foobar")))
 	require.Nil(t, err)
 
 	expected := `breaking_changes: []

--- a/internal/changelog/fragment/creator_internal_test.go
+++ b/internal/changelog/fragment/creator_internal_test.go
@@ -47,7 +47,8 @@ func TestSanitizeFilename(t *testing.T) {
 func TestCreate(t *testing.T) {
 	fc := TestNewCreator()
 
-	fc.Create("foobar")
+	err := fc.Create("foobar")
+	require.Nil(t, err)
 
 	content, err := afero.ReadFile(fc.fs, path.Join(fc.location, fc.filename("foobar")))
 	require.Nil(t, err)

--- a/internal/changelog/fragment/creator_internal_test.go
+++ b/internal/changelog/fragment/creator_internal_test.go
@@ -53,11 +53,14 @@ func TestCreate(t *testing.T) {
 	require.Nil(t, err)
 
 	expected := `breaking_changes: []
-enhancements: []
-bugfixes: []
-security_fixes: []
-known_issues: []
 deprecations: []
+bugfixes: []
+enhancements: []
+features: []
+known_issues: []
+security: []
+upgrades: []
+other: []
 `
 	got := string(content)
 	assert.Equal(t, expected, got)

--- a/internal/changelog/fragment/creator_internal_test.go
+++ b/internal/changelog/fragment/creator_internal_test.go
@@ -1,0 +1,76 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package fragment
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilename(t *testing.T) {
+	fc := TestNewCreator()
+
+	expected := "1647345675-foobar.yaml"
+	got := fc.filename("foobar")
+	assert.Equal(t, expected, got)
+}
+
+func TestSanitizeFilename(t *testing.T) {
+	type test struct {
+		input string
+		want  string
+	}
+
+	tests := []test{
+		{input: "foo bar", want: "foo-bar"},
+		{input: "foo bar foobar", want: "foo-bar-foobar"},
+		{input: "foo/bar", want: "foo-bar"},
+		{input: "foo\\bar", want: "foo-bar"},
+		{input: "foo bar/foobar\\", want: "foo-bar-foobar-"},
+	}
+
+	for _, tc := range tests {
+		got := sanitizeFilename(tc.input)
+		if !reflect.DeepEqual(tc.want, got) {
+			t.Fatalf("expected: %v, got: %v", tc.want, got)
+		}
+	}
+}
+
+func TestCreate(t *testing.T) {
+	fc := TestNewCreator()
+
+	fc.Create("foobar")
+
+	content, err := afero.ReadFile(fc.fs, fc.filename("foobar"))
+	require.Nil(t, err)
+
+	expected := `breaking_changes: []
+enhancements: []
+bugfixes: []
+security_fixes: []
+known_issues: []
+deprecations: []
+`
+	got := string(content)
+	assert.Equal(t, expected, got)
+}

--- a/internal/changelog/fragment/creator_internal_test.go
+++ b/internal/changelog/fragment/creator_internal_test.go
@@ -1,19 +1,6 @@
-// Licensed to Elasticsearch B.V. under one or more contributor
-// license agreements. See the NOTICE file distributed with
-// this work for additional information regarding copyright
-// ownership. Elasticsearch B.V. licenses this file to you under
-// the Apache License, Version 2.0 (the "License"); you may
-// not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package fragment
 

--- a/internal/changelog/fragment/creator_internal_test.go
+++ b/internal/changelog/fragment/creator_internal_test.go
@@ -46,11 +46,10 @@ func TestSanitizeFilename(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	fc := TestNewCreator()
-	location := afero.GetTempDir(fc.fs, "testdata")
 
-	fc.Create(location, "foobar")
+	fc.Create("foobar")
 
-	content, err := afero.ReadFile(fc.fs, path.Join(location, fc.filename("foobar")))
+	content, err := afero.ReadFile(fc.fs, path.Join(fc.location, fc.filename("foobar")))
 	require.Nil(t, err)
 
 	expected := `breaking_changes: []

--- a/internal/changelog/fragment/fragment.go
+++ b/internal/changelog/fragment/fragment.go
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package fragment
+
+type Fragment struct {
+	Major         []string `yaml:"breaking_changes"`
+	Minor         []string `yaml:"enhancements"`
+	Patch         []string `yaml:"bugfixes"`
+	SecurityFixes []string `yaml:"security_fixes"`
+	KnownIssues   []string `yaml:"known_issues"`
+	Deprecations  []string `yaml:"deprecations"`
+}

--- a/internal/changelog/fragment/fragment.go
+++ b/internal/changelog/fragment/fragment.go
@@ -5,10 +5,13 @@
 package fragment
 
 type Fragment struct {
-	Major         []string `yaml:"breaking_changes"`
-	Minor         []string `yaml:"enhancements"`
-	Patch         []string `yaml:"bugfixes"`
-	SecurityFixes []string `yaml:"security_fixes"`
-	KnownIssues   []string `yaml:"known_issues"`
-	Deprecations  []string `yaml:"deprecations"`
+	BreakingChanges []string `yaml:"breaking_changes"`
+	Deprecations    []string `yaml:"deprecations"`
+	Bugfixes        []string `yaml:"bugfixes"`
+	Enhancements    []string `yaml:"enhancements"`
+	Features        []string `yaml:"features"`
+	KnownIssues     []string `yaml:"known_issues"`
+	Security        []string `yaml:"security"`
+	Upgrades        []string `yaml:"upgrades"`
+	Other           []string `yaml:"other"`
 }

--- a/internal/changelog/fragment/fragment.go
+++ b/internal/changelog/fragment/fragment.go
@@ -1,19 +1,6 @@
-// Licensed to Elasticsearch B.V. under one or more contributor
-// license agreements. See the NOTICE file distributed with
-// this work for additional information regarding copyright
-// ownership. Elasticsearch B.V. licenses this file to you under
-// the Apache License, Version 2.0 (the "License"); you may
-// not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package fragment
 

--- a/internal/gitreporoot/gitreporoot.go
+++ b/internal/gitreporoot/gitreporoot.go
@@ -1,0 +1,23 @@
+/*
+gitreporoot package implement functionalities to find the Git repository root folder.
+
+The package uses a shell execution of git CLI to get the repo root, as this functionality is still
+not supported in https://github.com/go-git/go-git
+*/
+package gitreporoot
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Find uses git via shell to locate the top level directory
+func Find() (string, error) {
+	p, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", fmt.Errorf("cannot find working tree top level path: %w", err)
+	}
+
+	return strings.TrimSpace(string(p)), nil
+}

--- a/internal/gitreporoot/gitreporoot_test.go
+++ b/internal/gitreporoot/gitreporoot_test.go
@@ -14,7 +14,7 @@ func TestFind(t *testing.T) {
 	require.Nil(t, err)
 
 	// NOTE: git rev-parse --show-toplevel doesn't seem to play out nice with repo in repo structures
-	// to avoid makind this more complex than needed, the current repo is leveraged, but this test
+	// to avoid making this more complex than needed, the current repo is leveraged, but this test
 	// is a bit brittle.
 	require.Equal(t, path.Join(os.Getenv("PWD"), "..", ".."), p)
 }

--- a/internal/gitreporoot/gitreporoot_test.go
+++ b/internal/gitreporoot/gitreporoot_test.go
@@ -1,0 +1,20 @@
+package gitreporoot_test
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/elastic/elastic-agent-changelog-tool/internal/gitreporoot"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFind(t *testing.T) {
+	p, err := gitreporoot.Find()
+	require.Nil(t, err)
+
+	// NOTE: git rev-parse --show-toplevel doesn't seem to play out nice with repo in repo structures
+	// to avoid makind this more complex than needed, the current repo is leveraged, but this test
+	// is a bit brittle.
+	require.Equal(t, path.Join(os.Getenv("PWD"), "..", ".."), p)
+}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -1,7 +1,12 @@
 package settings
 
 import (
+	"log"
+	"os"
+	"path"
+
 	"github.com/OpenPeeDeeP/xdg"
+	"github.com/elastic/elastic-agent-changelog-tool/internal/gitreporoot"
 	"github.com/spf13/viper"
 )
 
@@ -18,6 +23,20 @@ func setDefaults() {
 	viper.SetDefault("cache_dir", xdg.CacheHome())
 	viper.SetDefault("config_dir", xdg.ConfigHome())
 	viper.SetDefault("data_dir", xdg.DataHome())
+
+	root, err := gitreporoot.Find()
+	if err != nil {
+		log.Printf("git repo root not found, $GIT_REPO_ROOT will be empty: %v\n", err)
+	} else {
+		os.Setenv("GIT_REPO_ROOT", root)
+	}
+
+	// fragment_root supports env var expansion
+	viper.SetDefault("fragment_root", "$GIT_REPO_ROOT")
+	viper.SetDefault("fragment_path", "changelog/fragments")
+	viper.SetDefault("fragment_location", path.Join(
+		os.ExpandEnv(viper.GetString("fragment_root")),
+		viper.GetString("fragment_path")))
 }
 
 func setConstants() {

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ func main() {
 	settings.Init()
 
 	rootCmd := cmd.RootCmd()
+	rootCmd.AddCommand(cmd.NewCmd())
 
 	err := rootCmd.Execute()
 	if err != nil {


### PR DESCRIPTION
Adding **changelog fragment** struct and `FragmentCreator` struct capable of generating a changelog fragment.

~Please note that the final changelog fragment content is still to be finalized.~ Content has been finalized.
