### PR TITLE
Implement changelog builder

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -9,11 +9,12 @@ import (
 	"fmt"
 
 	"github.com/elastic/elastic-agent-changelog-tool/internal/changelog"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-func BuildCmd() *cobra.Command {
+func BuildCmd(fs afero.Fs) *cobra.Command {
 
 	buildCmd := &cobra.Command{
 		Use:  "build",
@@ -26,7 +27,7 @@ func BuildCmd() *cobra.Command {
 			src := viper.GetString("fragment_location")
 			dest := viper.GetString("changelog_destination")
 
-			b := changelog.NewBuilder(filename, "8.2.1", src, dest)
+			b := changelog.NewBuilder(fs, filename, "8.2.1", src, dest)
 
 			if err := b.Build(); err != nil {
 				return fmt.Errorf("cannot build changelog: %w", err)

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -1,7 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License
-// 2.0; you may not use this file except in compliance with the Elastic License
-// 2.0.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package cmd
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -1,0 +1,40 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/elastic/elastic-agent-changelog-tool/internal/changelog"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func BuildCmd() *cobra.Command {
+
+	buildCmd := &cobra.Command{
+		Use:  "build",
+		Long: "Create changelog from fragments",
+		Args: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			filename := viper.GetString("changelog_filename")
+			src := viper.GetString("fragment_location")
+			dest := viper.GetString("changelog_destination")
+
+			b := changelog.NewBuilder(filename, "8.2.1", src, dest)
+
+			if err := b.Build(); err != nil {
+				return fmt.Errorf("cannot build changelog: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	return buildCmd
+}

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -1,0 +1,45 @@
+package cmd_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent-changelog-tool/cmd"
+	"github.com/elastic/elastic-agent-changelog-tool/internal/changelog"
+	"github.com/elastic/elastic-agent-changelog-tool/internal/changelog/fragment"
+	"github.com/spf13/afero"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestBuildCmd_default(t *testing.T) {
+	testFs := afero.NewMemMapFs()
+	c := fragment.NewCreator(testFs, viper.GetString("fragment_location"))
+	c.Create("foo")
+	// NOTE: sleeping to produce different fragment's timestamps
+	time.Sleep(1 * time.Second)
+	c.Create("bar")
+
+	cmd := cmd.BuildCmd(testFs)
+
+	b := new(bytes.Buffer)
+	cmd.SetOut(b)
+
+	err := cmd.Execute()
+	require.Nil(t, err)
+
+	content, err := afero.ReadFile(testFs, viper.GetString("changelog_destination"))
+	require.Nil(t, err)
+
+	ch := changelog.Changelog{}
+	err = yaml.Unmarshal(content, &ch)
+	require.Nil(t, err)
+
+	fmt.Println(ch)
+
+	require.Equal(t, "8.2.1", ch.Version)
+	require.Len(t, ch.Entries, 2)
+}

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -22,17 +22,19 @@ import (
 func TestBuildCmd_default(t *testing.T) {
 	testFs := afero.NewMemMapFs()
 	c := fragment.NewCreator(testFs, viper.GetString("fragment_location"))
-	c.Create("foo")
+	err := c.Create("foo")
+	require.Nil(t, err)
 	// NOTE: sleeping to produce different fragment's timestamps
 	time.Sleep(1 * time.Second)
-	c.Create("bar")
+	err = c.Create("bar")
+	require.Nil(t, err)
 
 	cmd := cmd.BuildCmd(testFs)
 
 	b := new(bytes.Buffer)
 	cmd.SetOut(b)
 
-	err := cmd.Execute()
+	err = cmd.Execute()
 	require.Nil(t, err)
 
 	content, err := afero.ReadFile(testFs, viper.GetString("changelog_destination"))

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package cmd_test
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 
 require (
@@ -36,5 +37,4 @@ require (
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/internal/changelog/builder.go
+++ b/internal/changelog/builder.go
@@ -1,0 +1,77 @@
+package changelog
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path"
+
+	"github.com/elastic/elastic-agent-changelog-tool/internal/changelog/fragment"
+	"github.com/spf13/afero"
+	"gopkg.in/yaml.v3"
+)
+
+type Builder struct {
+	changelog Changelog
+	filename  string
+	fs        afero.Fs
+	// src is the source location to gather changelog fragments
+	src string
+	// dest is the destination location where the changelog is written to
+	dest string
+}
+
+func NewBuilder(filename, version, src, dest string) *Builder {
+	return &Builder{
+		changelog: Changelog{Version: version},
+		filename:  filename,
+		fs:        afero.NewOsFs(),
+		src:       src,
+		dest:      dest,
+	}
+}
+
+var changelogFilePerm = os.FileMode(0660)
+var errNoFragments = errors.New("no fragments found in the source folder")
+
+func (b Builder) Build() error {
+	log.Printf("building changelog for version: %s\n", b.changelog.Version)
+	log.Printf("collecting fragments from %s\n", b.src)
+
+	var files []string
+	err := afero.Walk(b.fs, b.src, func(path string, info os.FileInfo, err error) error {
+		if info, err := b.fs.Stat(path); err == nil && !info.IsDir() {
+			files = append(files, path)
+		} else {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("cannot walk path %s: %w", b.src, err)
+	}
+
+	if len(files) == 0 {
+		return errNoFragments
+	}
+
+	for _, file := range files {
+		log.Printf("parsing %s", file)
+
+		f, err := fragment.Load(b.fs, file)
+		if err != nil {
+			return fmt.Errorf("cannot load fragment from file %s: %w", file, err)
+		}
+
+		b.changelog.Entries = append(b.changelog.Entries, EntryFromFragment(f))
+	}
+
+	data, err := yaml.Marshal(&b.changelog)
+	if err != nil {
+		return fmt.Errorf("cannot marshall changelog: %w", err)
+	}
+
+	return afero.WriteFile(b.fs, path.Join(b.dest, b.filename), data, changelogFilePerm)
+}

--- a/internal/changelog/builder.go
+++ b/internal/changelog/builder.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package changelog
 
 import (

--- a/internal/changelog/builder.go
+++ b/internal/changelog/builder.go
@@ -22,11 +22,11 @@ type Builder struct {
 	dest string
 }
 
-func NewBuilder(filename, version, src, dest string) *Builder {
+func NewBuilder(fs afero.Fs, filename, version, src, dest string) *Builder {
 	return &Builder{
 		changelog: Changelog{Version: version},
 		filename:  filename,
-		fs:        afero.NewOsFs(),
+		fs:        fs,
 		src:       src,
 		dest:      dest,
 	}

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package changelog
 
 type Changelog struct {

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -1,0 +1,6 @@
+package changelog
+
+type Changelog struct {
+	Version string  `yaml:"version"`
+	Entries []Entry `yaml:"entries"`
+}

--- a/internal/changelog/entry.go
+++ b/internal/changelog/entry.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package changelog
 
 import "github.com/elastic/elastic-agent-changelog-tool/internal/changelog/fragment"

--- a/internal/changelog/entry.go
+++ b/internal/changelog/entry.go
@@ -21,19 +21,6 @@ type Entry struct {
 	File        FragmentFileInfo `yaml:"file"`
 }
 
-const (
-	// NOTE: Kind values should be aligned with supported type from doc.elastic.co
-	kindBreakingChange = "breaking-change"
-	kindDeprecation    = "deprecation"
-	kindBugfix         = "bug-fix"
-	kindEnhancement    = "enhancement"
-	kindFeature        = "feature"
-	kindKnownIssue     = "known-issue"
-	kindSecurity       = "security"
-	kindUpgrade        = "upgrade"
-	kindOther          = "other"
-)
-
 // EntriesFromFragment returns one or more entries based on the fragment File.
 // A single Fragment can contain multiple Changelog entries.
 func EntryFromFragment(f fragment.File) Entry {

--- a/internal/changelog/entry.go
+++ b/internal/changelog/entry.go
@@ -1,0 +1,75 @@
+package changelog
+
+import "github.com/elastic/elastic-agent-changelog-tool/internal/changelog/fragment"
+
+type FragmentFileInfo struct {
+	Name     string `yaml:"name"`
+	Checksum string `yaml:"checksum"`
+}
+
+type Entry struct {
+	Summary     string           `yaml:"summary"`
+	Description string           `yaml:"description"`
+	Kind        Kind             `yaml:"kind"`
+	LinkedPR    int              `yaml:"pr"`
+	LinkedIssue int              `yaml:"issue"`
+	Timestamp   int64            `yaml:"timestamp"`
+	File        FragmentFileInfo `yaml:"file"`
+}
+
+const (
+	// NOTE: Kind values should be aligned with supported type from doc.elastic.co
+	kindBreakingChange = "breaking-change"
+	kindDeprecation    = "deprecation"
+	kindBugfix         = "bug-fix"
+	kindEnhancement    = "enhancement"
+	kindFeature        = "feature"
+	kindKnownIssue     = "known-issue"
+	kindSecurity       = "security"
+	kindUpgrade        = "upgrade"
+	kindOther          = "other"
+)
+
+// EntriesFromFragment returns one or more entries based on the fragment File.
+// A single Fragment can contain multiple Changelog entries.
+func EntryFromFragment(f fragment.File) Entry {
+	e := Entry{
+		Summary:     f.Fragment.Summary,
+		Description: f.Fragment.Description,
+		Kind:        kind2kind(f),
+		LinkedPR:    f.Fragment.Pr,
+		LinkedIssue: f.Fragment.Issue,
+		Timestamp:   f.Timestamp,
+		File: FragmentFileInfo{
+			Name:     f.Name,
+			Checksum: f.Checksum(),
+		},
+	}
+
+	return e
+}
+
+func kind2kind(f fragment.File) Kind {
+	switch f.Fragment.Kind {
+	case string(BreakingChange):
+		return BreakingChange
+	case string(BugFix):
+		return BugFix
+	case string(Deprecation):
+		return Deprecation
+	case string(Enhancement):
+		return Enhancement
+	case string(Feature):
+		return Feature
+	case string(KnownIssue):
+		return KnownIssue
+	case string(Security):
+		return Security
+	case string(Upgrade):
+		return Upgrade
+	case string(Other):
+		return Other
+	default:
+		return Unknown
+	}
+}

--- a/internal/changelog/entry_test.go
+++ b/internal/changelog/entry_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package changelog_test
 
 import (

--- a/internal/changelog/entry_test.go
+++ b/internal/changelog/entry_test.go
@@ -1,0 +1,123 @@
+package changelog_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/elastic/elastic-agent-changelog-tool/internal/changelog"
+	"github.com/elastic/elastic-agent-changelog-tool/internal/changelog/fragment"
+	"github.com/spf13/afero"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func loadEntries(t *testing.T, fixture string) (fragment.File, changelog.Entry) {
+	fs := afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs())
+
+	viper.Set("fragment_location", "testdata")
+
+	f1, err := fragment.Load(fs, path.Join(viper.GetString("fragment_location"), fixture))
+	require.Nil(t, err)
+
+	return f1, changelog.EntryFromFragment(f1)
+}
+
+func TestEntriesFromFragment_breaking(t *testing.T) {
+	fixture := "1648040928-breaking-change.yaml"
+	f, e := loadEntries(t, fixture)
+	require.Equal(t, e.File.Name, fixture)
+	require.Equal(t, e.File.Checksum, f.Checksum())
+	require.Equal(t, e.Timestamp, f.Timestamp)
+	require.Equal(t, e.Kind, changelog.BreakingChange)
+	require.Equal(t, e.Summary, f.Fragment.Summary)
+}
+
+func TestEntriesFromFragment_deprecation(t *testing.T) {
+	fixture := "1648040928-bug-fix.yaml"
+	f, e := loadEntries(t, fixture)
+	require.Equal(t, e.File.Name, fixture)
+	require.Equal(t, e.File.Checksum, f.Checksum())
+	require.Equal(t, e.Timestamp, f.Timestamp)
+	require.Equal(t, e.Kind, changelog.BugFix)
+	require.Equal(t, e.Summary, f.Fragment.Summary)
+}
+
+func TestEntriesFromFragment_bugfix(t *testing.T) {
+	fixture := "1648040928-deprecation.yaml"
+	f, e := loadEntries(t, fixture)
+	require.Equal(t, e.File.Name, fixture)
+	require.Equal(t, e.File.Checksum, f.Checksum())
+	require.Equal(t, e.Timestamp, f.Timestamp)
+	require.Equal(t, e.Kind, changelog.Deprecation)
+	require.Equal(t, e.Summary, f.Fragment.Summary)
+}
+
+func TestEntriesFromFragment_enhancement(t *testing.T) {
+	fixture := "1648040928-enhancement.yaml"
+	f, e := loadEntries(t, fixture)
+	require.Equal(t, e.File.Name, fixture)
+	require.Equal(t, e.File.Checksum, f.Checksum())
+	require.Equal(t, e.Timestamp, f.Timestamp)
+	require.Equal(t, e.Kind, changelog.Enhancement)
+	require.Equal(t, e.Summary, f.Fragment.Summary)
+}
+
+func TestEntriesFromFragment_feature(t *testing.T) {
+	fixture := "1648040928-feature.yaml"
+	f, e := loadEntries(t, fixture)
+	require.Equal(t, e.File.Name, fixture)
+	require.Equal(t, e.File.Checksum, f.Checksum())
+	require.Equal(t, e.Timestamp, f.Timestamp)
+	require.Equal(t, e.Kind, changelog.Feature)
+	require.Equal(t, e.Summary, f.Fragment.Summary)
+}
+
+func TestEntriesFromFragment_knownissue(t *testing.T) {
+	fixture := "1648040928-known-issue.yaml"
+	f, e := loadEntries(t, fixture)
+	require.Equal(t, e.File.Name, fixture)
+	require.Equal(t, e.File.Checksum, f.Checksum())
+	require.Equal(t, e.Timestamp, f.Timestamp)
+	require.Equal(t, e.Kind, changelog.KnownIssue)
+	require.Equal(t, e.Summary, f.Fragment.Summary)
+
+}
+func TestEntriesFromFragment_security(t *testing.T) {
+	fixture := "1648040928-security.yaml"
+	f, e := loadEntries(t, fixture)
+	require.Equal(t, e.File.Name, fixture)
+	require.Equal(t, e.File.Checksum, f.Checksum())
+	require.Equal(t, e.Timestamp, f.Timestamp)
+	require.Equal(t, e.Kind, changelog.Security)
+	require.Equal(t, e.Summary, f.Fragment.Summary)
+
+}
+func TestEntriesFromFragment_upgrade(t *testing.T) {
+	fixture := "1648040928-upgrade.yaml"
+	f, e := loadEntries(t, fixture)
+	require.Equal(t, e.File.Name, fixture)
+	require.Equal(t, e.File.Checksum, f.Checksum())
+	require.Equal(t, e.Timestamp, f.Timestamp)
+	require.Equal(t, e.Kind, changelog.Upgrade)
+	require.Equal(t, e.Summary, f.Fragment.Summary)
+
+}
+func TestEntriesFromFragment_other(t *testing.T) {
+	fixture := "1648040928-other.yaml"
+	f, e := loadEntries(t, fixture)
+	require.Equal(t, e.File.Name, fixture)
+	require.Equal(t, e.File.Checksum, f.Checksum())
+	require.Equal(t, e.Timestamp, f.Timestamp)
+	require.Equal(t, e.Kind, changelog.Other)
+	require.Equal(t, e.Summary, f.Fragment.Summary)
+}
+
+func TestEntriesFromFragment_unknown(t *testing.T) {
+	fixture := "1648040928-unknown.yaml"
+	f, e := loadEntries(t, fixture)
+	require.Equal(t, e.File.Name, fixture)
+	require.Equal(t, e.File.Checksum, f.Checksum())
+	require.Equal(t, e.Timestamp, f.Timestamp)
+	require.Equal(t, e.Kind, changelog.Unknown)
+	require.Equal(t, e.Summary, f.Fragment.Summary)
+}

--- a/internal/changelog/fragment/file.go
+++ b/internal/changelog/fragment/file.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package fragment
 
 import (

--- a/internal/changelog/fragment/file.go
+++ b/internal/changelog/fragment/file.go
@@ -1,0 +1,94 @@
+package fragment
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/afero"
+	"gopkg.in/yaml.v3"
+)
+
+// File contains information of a Fragment file on disk.
+type File struct {
+	fs afero.Fs
+
+	Content   []byte
+	Fragment  Fragment
+	Name      string
+	Timestamp int64
+	Title     string
+}
+
+// Load fills a File struct with data from a file on disk.
+func Load(fs afero.Fs, path string) (File, error) {
+	f := File{
+		fs: fs,
+
+		Name:     filepath.Base(path),
+		Fragment: Fragment{},
+	}
+
+	ts, err := gettimestamp(f.Name)
+	if err != nil {
+		return f, fmt.Errorf("cannot extract timestamp from file name: %w", err)
+	}
+
+	f.Timestamp = ts
+	f.Title = gettitle(f.Name)
+
+	content, err := getcontent(f.fs, path)
+	if err != nil {
+		return f, err
+	}
+
+	f.Content = content
+
+	if err := yaml.Unmarshal(content, &f.Fragment); err != nil {
+		return f, fmt.Errorf("cannot unmarshal file: %w", err)
+	}
+
+	return f, nil
+}
+
+// Checksum computes SHA1 for file content and returns it as hex encoded string.
+func (f File) Checksum() string {
+	h := sha1.New()
+	h.Write(f.Content)
+	checksum := hex.EncodeToString([]byte(h.Sum(nil)))
+
+	return checksum
+}
+
+// gettimestamp extracts timestamp from file name.
+func gettimestamp(path string) (int64, error) {
+	basename := filepath.Base(path)
+	split := strings.Split(basename, "-")
+	i, err := strconv.ParseInt(split[0], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("cannot parse string to int: %w", err)
+	}
+
+	return int64(i), nil
+}
+
+// gettitle extracts fragment title from file name.
+func gettitle(path string) string {
+	basename := filepath.Base(path)
+	split := strings.Split(basename, "-")
+	title := strings.TrimSuffix(strings.Join(split[1:], "-"), filepath.Ext(basename))
+	return title
+}
+
+// getcontent reads fragment file content.
+func getcontent(fs afero.Fs, path string) ([]byte, error) {
+	content, err := afero.ReadFile(fs, path)
+	if err != nil {
+		return []byte{}, fmt.Errorf("cannot read file: %w", err)
+	}
+
+	return content, nil
+}

--- a/internal/changelog/fragment/file_test.go
+++ b/internal/changelog/fragment/file_test.go
@@ -1,0 +1,45 @@
+package fragment_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/elastic/elastic-agent-changelog-tool/internal/changelog/fragment"
+	"github.com/spf13/afero"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFile(t *testing.T) {
+	fs := afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs())
+
+	viper.Set("fragment_location", "testdata")
+
+	f1, err := fragment.Load(fs, path.Join(viper.GetString("fragment_location"), "1648040924-breaking-change.yaml"))
+	require.Nil(t, err)
+
+	require.Equal(t, f1.Title, "breaking-change")
+	require.Equal(t, f1.Timestamp, int64(1648040924))
+	require.Equal(t, f1.Fragment.Kind, "breaking-change")
+	require.Equal(t, f1.Fragment.Summary, "a change with breaking changes")
+
+	f2, err := fragment.Load(fs, path.Join(viper.GetString("fragment_location"), "1648040928-enhancement.yaml"))
+	require.Nil(t, err)
+
+	require.Equal(t, f2.Title, "enhancement")
+	require.Equal(t, f2.Timestamp, int64(1648040928))
+	require.Equal(t, f2.Fragment.Kind, "enhancement")
+	require.Equal(t, f2.Fragment.Summary, "a new feature")
+
+}
+
+func TestFileChecksum(t *testing.T) {
+	fs := afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs())
+
+	viper.Set("fragment_location", "testdata")
+
+	f, err := fragment.Load(fs, path.Join(viper.GetString("fragment_location"), "1648040924-breaking-change.yaml"))
+	require.Nil(t, err)
+
+	require.Equal(t, f.Checksum(), "f085dd487a7c88d165235546cdb528cc4e94a046")
+}

--- a/internal/changelog/fragment/file_test.go
+++ b/internal/changelog/fragment/file_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package fragment_test
 
 import (

--- a/internal/changelog/fragment/testdata/1648040924-breaking-change.yaml
+++ b/internal/changelog/fragment/testdata/1648040924-breaking-change.yaml
@@ -1,0 +1,3 @@
+kind: breaking-change
+summary: a change with breaking changes
+

--- a/internal/changelog/fragment/testdata/1648040928-enhancement.yaml
+++ b/internal/changelog/fragment/testdata/1648040928-enhancement.yaml
@@ -1,0 +1,2 @@
+kind: enhancement
+summary: a new feature

--- a/internal/changelog/kind.go
+++ b/internal/changelog/kind.go
@@ -1,0 +1,18 @@
+package changelog
+
+type Kind string
+
+const (
+	// NOTE: Kind values should be aligned with supported type from doc.elastic.co
+	BreakingChange Kind = "breaking-change"
+	Deprecation    Kind = "deprecation"
+	BugFix         Kind = "bug-fix"
+	Enhancement    Kind = "enhancement"
+	Feature        Kind = "feature"
+	KnownIssue     Kind = "known-issue"
+	Security       Kind = "security"
+	Upgrade        Kind = "upgrade"
+	Other          Kind = "other"
+	// Unknown kind is used if no matching kind is found
+	Unknown Kind = "unknown"
+)

--- a/internal/changelog/kind.go
+++ b/internal/changelog/kind.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package changelog
 
 type Kind string

--- a/internal/changelog/testdata/1648040928-breaking-change.yaml
+++ b/internal/changelog/testdata/1648040928-breaking-change.yaml
@@ -1,0 +1,2 @@
+kind: breaking-change
+summary: a breaking change

--- a/internal/changelog/testdata/1648040928-bug-fix.yaml
+++ b/internal/changelog/testdata/1648040928-bug-fix.yaml
@@ -1,0 +1,2 @@
+kind: bug-fix
+summary: a bugfix

--- a/internal/changelog/testdata/1648040928-deprecation.yaml
+++ b/internal/changelog/testdata/1648040928-deprecation.yaml
@@ -1,0 +1,2 @@
+kind: deprecation
+summary: a deprecation

--- a/internal/changelog/testdata/1648040928-enhancement.yaml
+++ b/internal/changelog/testdata/1648040928-enhancement.yaml
@@ -1,0 +1,2 @@
+kind: enhancement
+summary: an enhancement

--- a/internal/changelog/testdata/1648040928-feature.yaml
+++ b/internal/changelog/testdata/1648040928-feature.yaml
@@ -1,0 +1,2 @@
+kind: feature
+summary: a feature

--- a/internal/changelog/testdata/1648040928-known-issue.yaml
+++ b/internal/changelog/testdata/1648040928-known-issue.yaml
@@ -1,0 +1,2 @@
+kind: known-issue
+summary: a known issue

--- a/internal/changelog/testdata/1648040928-other.yaml
+++ b/internal/changelog/testdata/1648040928-other.yaml
@@ -1,0 +1,2 @@
+kind: other
+summary: some other change

--- a/internal/changelog/testdata/1648040928-security.yaml
+++ b/internal/changelog/testdata/1648040928-security.yaml
@@ -1,0 +1,2 @@
+kind: security
+summary: a security consideration

--- a/internal/changelog/testdata/1648040928-unknown.yaml
+++ b/internal/changelog/testdata/1648040928-unknown.yaml
@@ -1,0 +1,2 @@
+kind: foobar # this is a wrong kind
+summary: a fragment with unknown kind

--- a/internal/changelog/testdata/1648040928-upgrade.yaml
+++ b/internal/changelog/testdata/1648040928-upgrade.yaml
@@ -1,0 +1,2 @@
+kind: upgrade
+summary: an upgrade

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -42,6 +42,9 @@ func setDefaults() {
 	viper.SetDefault("fragment_location", path.Join(
 		os.ExpandEnv(viper.GetString("fragment_root")),
 		viper.GetString("fragment_path")))
+
+	viper.SetDefault("changelog_destination", ".")
+	viper.SetDefault("changelog_filename", "changelog.yaml")
 }
 
 func setConstants() {

--- a/main.go
+++ b/main.go
@@ -9,13 +9,16 @@ import (
 
 	"github.com/elastic/elastic-agent-changelog-tool/cmd"
 	"github.com/elastic/elastic-agent-changelog-tool/internal/settings"
+	"github.com/spf13/afero"
 )
 
 func main() {
 	settings.Init()
 
+	appFs := afero.NewOsFs()
+
 	rootCmd := cmd.RootCmd()
-	rootCmd.AddCommand(cmd.BuildCmd())
+	rootCmd.AddCommand(cmd.BuildCmd(appFs))
 	rootCmd.AddCommand(cmd.NewCmd())
 	rootCmd.AddCommand(cmd.FindPRCommand())
 	rootCmd.AddCommand(cmd.VersionCmd())

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ func main() {
 	settings.Init()
 
 	rootCmd := cmd.RootCmd()
+	rootCmd.AddCommand(cmd.BuildCmd())
 	rootCmd.AddCommand(cmd.NewCmd())
 	rootCmd.AddCommand(cmd.FindPRCommand())
 	rootCmd.AddCommand(cmd.VersionCmd())


### PR DESCRIPTION
This PR is based on #13 so it **must** be merged after that. 
It needs #17 to be merged before merge.
Closes #20.

Add `changelog.Builder` struct implementing the logic to build a changelog YAML representation where **changelog fragments** are deduplicated and merged into a list of `changelog.Entry`.

