### PR TITLE
Remove Lint stage from Jenkins

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -33,23 +33,6 @@ pipeline {
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }
-    stage('Lint'){
-      options { skipDefaultCheckout() }
-      steps {
-        withGithubNotify(context: "Lint") {
-          dir("${BASE_DIR}"){
-            withGoEnv(){
-              setEnvVar('GO_VERSION', readFile(".go-version").trim())
-              sh(label: 'lint', script: '''
-                go mod tidy && git diff --exit-code
-                gofmt -l . | read && echo "Code differs from gofmt's style. Run 'gofmt -w .'" 1>&2 && exit 1 || true
-              ''')
-              sh(label: 'Go vet', script: 'go vet')
-            }
-          }
-        }
-      }
-    }
     stage('build'){
       options { skipDefaultCheckout() }
       steps {

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -4,7 +4,7 @@ name: Pull request checks
 on: [pull_request]
 
 jobs:
-  lint:
+  gomod:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,9 +25,43 @@ jobs:
         # tidy go mod and check for differences
         run: "go mod tidy && git diff --exit-code"
 
+  gofmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: get go version
+        run: |
+          gv=$(cat .go-version)
+          echo "::set-output name=go::$gv"
+        id: version
+
+      - name: install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: "${{steps.version.outputs.go}}"
+
       - name: check format
         # exit with 0 only if gofmt returns 0 lines
         run: "exit $(gofmt | wc -l)"
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: get go version
+        run: |
+          gv=$(cat .go-version)
+          echo "::set-output name=go::$gv"
+        id: version
+
+      - name: install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: "${{steps.version.outputs.go}}"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -85,6 +85,9 @@ jobs:
         with:
           go-version: "${{steps.version.outputs.go}}"
 
+      - name: install go-licenser
+        run: "go get github.com/elastic/go-licenser"
+
       - name: check license
         # -d returns files without proper header
         run: "go run github.com/elastic/go-licenser -license Elasticv2 -d"

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -10,9 +10,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - run: |
+      - name: get go version
+        run: |
           gv=$(cat .go-version)
-          echo "::set-output name={go}::{$gv}"
+          echo "::set-output name=go::$gv"
         id: version
 
       - name: install Go
@@ -39,9 +40,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - run: |
+      - name: get go version
+        run: |
           gv=$(cat .go-version)
-          echo "::set-output name={go}::{$gv}"
+          echo "::set-output name=go::$gv"
         id: version
 
       - name: install Go

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -20,6 +20,10 @@ jobs:
         with:
           go-version: "${{steps.version.outputs.go}}"
 
+      - name: check go.mod
+        # tidy go mod and check for differences
+        run: "go mod tidy && git diff --exit-code"
+
       - name: check format
         # exit with 0 only if gofmt returns 0 lines
         run: "exit $(gofmt | wc -l)"

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.33
+          version: v1.45
 
   license:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As per discussion with @v1v we can move lint stage to GitHub Actions, to
provide faster feedback and speed up the build & test phases.

This commit removes the `Lint` stage from Jenkins and add the missing
tasks in `lint` GitHub Actions job.
Note that `go vet` is included in `golangci-lint`.
