### PR TITLE
Fix Fragment Creator timestamp returning always same value

### DIFF
--- a/internal/changelog/fragment/creator.go
+++ b/internal/changelog/fragment/creator.go
@@ -16,20 +16,21 @@ import (
 
 // timestamp represent a function providing a timestamp.
 // It's used to allow replacing the value with a known one during testing.
-type timestamp func() int64
+type timestamp func() time.Time
 
 func NewCreator(fs afero.Fs, location string) FragmentCreator {
 	return FragmentCreator{
 		fs:        fs,
 		location:  location,
-		timestamp: time.Now().Unix,
+		timestamp: time.Now,
 	}
 }
 
 // TestNewCreator sets up a FragmentCreator configured to be used in testing.
 func TestNewCreator() FragmentCreator {
 	f := NewCreator(afero.NewMemMapFs(), "testdata")
-	f.timestamp = func() int64 { return 1647345675 }
+	tz, _ := time.LoadLocation("MST")
+	f.timestamp = func() time.Time { return time.Date(2006, time.January, 2, 15, 4, 5, 0, tz) }
 	return f
 }
 
@@ -47,7 +48,7 @@ func (c FragmentCreator) Location() string {
 // filename computes the filename for the changelog fragment to be created.
 // To provide unique names the provided slug is prepended with current timestamp.
 func (f FragmentCreator) filename(slug string) string {
-	filename := fmt.Sprintf("%d-%s.yaml", f.timestamp(), sanitizeFilename(slug))
+	filename := fmt.Sprintf("%d-%s.yaml", f.timestamp().Unix(), sanitizeFilename(slug))
 	return filename
 }
 

--- a/internal/changelog/fragment/creator_internal_test.go
+++ b/internal/changelog/fragment/creator_internal_test.go
@@ -5,9 +5,11 @@
 package fragment
 
 import (
+	"log"
 	"path"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -17,9 +19,26 @@ import (
 func TestFilename(t *testing.T) {
 	fc := TestNewCreator()
 
-	expected := "1647345675-foobar.yaml"
+	expected := "1136239445-foobar.yaml"
 	got := fc.filename("foobar")
 	assert.Equal(t, expected, got)
+}
+
+func TestTimestamp_default(t *testing.T) {
+	// NOTE: using sleep to test timestamp default function ability to return different values.
+	// Sleeping 1 second to test UNIX timestamp (with second resolution).
+	log.Println("SLOW TEST, it sleeps")
+	testFs := afero.NewMemMapFs()
+	fc := NewCreator(testFs, "foobar")
+
+	t1 := fc.timestamp()
+	time.Sleep(1 * time.Second)
+	t2 := fc.timestamp()
+	time.Sleep(1 * time.Second)
+	t3 := fc.timestamp()
+
+	require.Greater(t, t2.Unix(), t1.Unix())
+	require.Greater(t, t3.Unix(), t2.Unix())
 }
 
 func TestSanitizeFilename(t *testing.T) {


### PR DESCRIPTION
The previous default value of `timestamp` function (`time.Now().Unix`)
always returned the same value, taken at the moment of `Creator`
initialization.

This was not the intended behaviour as the `Creator.Create()` method
supports a `slug` argument, making it possible to create multiple
fragments using a single `Creator`.

To solve this the `timestamp()` function now returns a `time.Time`, that
can be converted to a UNIX timestamp when needed (when calling
`filename()`).

Tests are provided to ensure multiple calls to `timestamp()` produce a
different result.
