### PR TITLE
Fix go-licenser go.mod changes

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -86,8 +86,8 @@ jobs:
           go-version: "${{steps.version.outputs.go}}"
 
       - name: install go-licenser
-        run: "go get github.com/elastic/go-licenser"
+        run: "go install github.com/elastic/go-licenser@latest"
 
       - name: check license
         # -d returns files without proper header
-        run: "go run github.com/elastic/go-licenser -license Elasticv2 -d"
+        run: "go-licenser -license Elasticv2 -d"

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -86,8 +86,14 @@ jobs:
           go-version: "${{steps.version.outputs.go}}"
 
       - name: install go-licenser
-        run: "go install github.com/elastic/go-licenser@latest"
+        run: |
+          ls
+          printenv GOPATH
+          printenv GOBIN
+          go install github.com/elastic/go-licenser@latest
 
       - name: check license
         # -d returns files without proper header
-        run: "go-licenser -license Elasticv2 -d"
+        run: |
+          GOBIN=$PWD/bin go install github.com/elastic/go-licenser@latest
+          ./bin/go-licenser -license Elasticv2 -d

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -85,13 +85,6 @@ jobs:
         with:
           go-version: "${{steps.version.outputs.go}}"
 
-      - name: install go-licenser
-        run: |
-          ls
-          printenv GOPATH
-          printenv GOBIN
-          go install github.com/elastic/go-licenser@latest
-
       - name: check license
         # -d returns files without proper header
         run: |

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 	go build -ldflags "$(VERSION_LDFLAGS)" -o elastic-agent-changelog-tool
 
 licenser:
-	go run github.com/elastic/go-licenser -license Elasticv2
+	go-licenser -license Elasticv2
 
 test:
 	go test -v ./...

--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ Tooling to manage the changelog for beats, Elastic Agent and Fleet Server
 ## Requirements
 
 `git` CLI should be installed and available.
+[`go-licenser`](https://github.com/elastic/go-licenser) CLI should be installed and available.


### PR DESCRIPTION
Running `go run ...go-licenser` updates the `go.mod` file. Each time a developer was running `make licenser` the go.mod was updated, but those changes were not to be committed, otherwise the CI would complain.

Solving this issue by using the `go-licenser` binary directly.
