### PR TITLE
Changelog builder improvements

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/elastic/elastic-agent-changelog-tool/internal/changelog"
 	"github.com/spf13/afero"
@@ -26,7 +27,12 @@ func BuildCmd(fs afero.Fs) *cobra.Command {
 			src := viper.GetString("fragment_location")
 			dest := viper.GetString("changelog_destination")
 
-			b := changelog.NewBuilder(fs, filename, "8.2.1", src, dest)
+			version, err := cmd.Flags().GetString("version")
+			if err != nil {
+				return fmt.Errorf("error parsing flag 'version': %w", err)
+			}
+
+			b := changelog.NewBuilder(fs, filename, version, src, dest)
 
 			if err := b.Build(); err != nil {
 				return fmt.Errorf("cannot build changelog: %w", err)
@@ -34,6 +40,13 @@ func BuildCmd(fs afero.Fs) *cobra.Command {
 
 			return nil
 		},
+	}
+
+	buildCmd.Flags().String("version", "", "The version of the consolidated changelog being created")
+	err := buildCmd.MarkFlagRequired("version")
+	if err != nil {
+		// NOTE: the only case this error appear is when the flag is not defined
+		log.Fatal(err)
 	}
 
 	return buildCmd

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/elastic/elastic-agent-changelog-tool/cmd"
 	"github.com/elastic/elastic-agent-changelog-tool/internal/changelog"
 	"github.com/elastic/elastic-agent-changelog-tool/internal/changelog/fragment"
+	"github.com/elastic/elastic-agent-changelog-tool/internal/settings"
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
@@ -22,6 +23,8 @@ import (
 )
 
 func TestBuildCmd(t *testing.T) {
+	settings.Init()
+
 	testFs := afero.NewMemMapFs()
 	c := fragment.NewCreator(testFs, viper.GetString("fragment_location"))
 	err := c.Create("foo")

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"path"
 	"testing"
 	"time"
 
@@ -47,7 +48,8 @@ func TestBuildCmd(t *testing.T) {
 	err = cmd.Execute()
 	require.Nil(t, err)
 
-	content, err := afero.ReadFile(testFs, viper.GetString("changelog_destination"))
+	changelogFile := path.Join(viper.GetString("changelog_destination"), viper.GetString("changelog_filename"))
+	content, err := afero.ReadFile(testFs, changelogFile)
 	require.Nil(t, err)
 
 	ch := changelog.Changelog{}

--- a/internal/changelog/builder.go
+++ b/internal/changelog/builder.go
@@ -77,5 +77,7 @@ func (b Builder) Build() error {
 		return fmt.Errorf("cannot marshall changelog: %w", err)
 	}
 
-	return afero.WriteFile(b.fs, path.Join(b.dest, b.filename), data, changelogFilePerm)
+	outFile := path.Join(b.dest, b.filename)
+	log.Printf("saving changelog in %s\n", outFile)
+	return afero.WriteFile(b.fs, outFile, data, changelogFilePerm)
 }


### PR DESCRIPTION
Add `--version` flag to `build` command (was hardcoded to `8.2.1` before).

Fix tests, that were passing but not correctly testing the build functionality.
