### PR TITLE
Add heuristics

### DIFF
--- a/internal/github/find-pr.go
+++ b/internal/github/find-pr.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/google/go-github/v32/github"
 )
@@ -30,7 +29,7 @@ func (s *BackportPRNumber) FindPullRequestID(pr *github.PullRequest) (int, error
 	rDigit, _ := regexp.Compile(`(\d+)`)
 
 	for _, label := range pr.Labels {
-		if strings.Contains(label.GetName(), "backport") {
+		if label.GetName() == "backport" {
 			for _, p := range patterns {
 				regexPattern, _ := regexp.Compile(p)
 				backport := regexPattern.FindString(pr.GetTitle())

--- a/internal/github/find-pr_test.go
+++ b/internal/github/find-pr_test.go
@@ -41,14 +41,17 @@ func TestFindPR_backport(t *testing.T) {
 	res, err := github.FindPR(ctx, c, "elastic", "beats", "fe25c73907336fc462d5e6e059d3cd86512484fe")
 	require.NoError(t, err)
 	require.Len(t, res.Items, 4)
+	// not a backport: https://github.com/elastic/beats/pull/31396
 	require.Equal(t, 31396, res.Items[0].PullRequestID)
-	require.Equal(t, 31417, res.Items[1].PullRequestID)
-	require.Equal(t, 31382, res.Items[2].PullRequestID)
-	require.Equal(t, 31343, res.Items[3].PullRequestID)
+	// backport: https://github.com/elastic/beats/pull/31417 => source: https://github.com/elastic/beats/issues/31013
+	require.Equal(t, 31013, res.Items[1].PullRequestID)
+	// backport: https://github.com/elastic/beats/pull/31396 => source: https://github.com/elastic/beats/issues/31369
+	require.Equal(t, 31369, res.Items[2].PullRequestID)
+	// backport: https://github.com/elastic/beats/pull/31343 => source: https://github.com/elastic/beats/pull/31279
+	require.Equal(t, 31279, res.Items[3].PullRequestID)
 }
 
 func TestFindPR_forwardport(t *testing.T) {
-	t.Skip("this behaviour is not yet implemented")
 	r, hc := getHttpClient(t)
 	defer r.Stop() //nolint:errcheck
 


### PR DESCRIPTION
Concerns Issue #11 

Heuristics should be constantly updated as more patterns get found.

- [x]  Initial heuristics which only fetches the main PR from the PR title/body in case of backport label
- [x]  Strategy pattern which allows easily adding new heuristics rules

Examples: 

1. Using `b8cf1e7995393db980ffffad4504a5175de450b8` commit hash from https://github.com/elastic/beats/pull/30626 correctly shows `29209` as being the main PR.