### PR TITLE
Enhance cmd tests

### DIFF
--- a/cmd/pr_has_fragment_test.go
+++ b/cmd/pr_has_fragment_test.go
@@ -20,12 +20,12 @@ func TestPrHasFragmentCmd_noArgs(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 
 	fs := afero.NewMemMapFs()
-	cmd := cmd.PrHasFragmentCommand(fs)
+	c := cmd.PrHasFragmentCommand(fs)
 
-	cmd.SetOut(ioutil.Discard)
-	cmd.SetErr(ioutil.Discard)
+	c.SetOut(ioutil.Discard)
+	c.SetErr(ioutil.Discard)
 
-	err := cmd.Execute()
+	err := c.Execute()
 	require.Error(t, err)
 }
 
@@ -35,15 +35,15 @@ func TestPrHasFragmentCmd_oneArg(t *testing.T) {
 	settings.Init()
 
 	fs := afero.NewMemMapFs()
-	cmd := cmd.PrHasFragmentCommand(fs)
+	c := cmd.PrHasFragmentCommand(fs)
 
 	b := new(bytes.Buffer)
-	cmd.SetOut(b)
-	cmd.SetErr(ioutil.Discard)
+	c.SetOut(b)
+	c.SetErr(ioutil.Discard)
 
-	cmd.SetArgs([]string{"--repo", "elastic-agent-changelog-tool", "29"})
+	c.SetArgs([]string{"--repo", "elastic-agent-changelog-tool", "29"})
 
-	err := cmd.Execute()
+	err := c.Execute()
 	require.Nil(t, err)
 }
 
@@ -53,14 +53,14 @@ func TestPrHasFragmentCmd_oneArgFailCase(t *testing.T) {
 	settings.Init()
 
 	fs := afero.NewMemMapFs()
-	cmd := cmd.PrHasFragmentCommand(fs)
+	c := cmd.PrHasFragmentCommand(fs)
 
 	b := new(bytes.Buffer)
-	cmd.SetOut(b)
-	cmd.SetErr(ioutil.Discard)
+	c.SetOut(b)
+	c.SetErr(ioutil.Discard)
 
-	cmd.SetArgs([]string{"--repo", "elastic-agent-changelog-tool", "33"})
+	c.SetArgs([]string{"--repo", "elastic-agent-changelog-tool", "33"})
 
-	err := cmd.Execute()
+	err := c.Execute()
 	require.Error(t, err)
 }

--- a/cmd/pr_has_fragment_test.go
+++ b/cmd/pr_has_fragment_test.go
@@ -7,6 +7,7 @@ package cmd_test
 import (
 	"bytes"
 	"io/ioutil"
+	"log"
 	"testing"
 
 	"github.com/elastic/elastic-agent-changelog-tool/cmd"
@@ -16,6 +17,8 @@ import (
 )
 
 func TestPrHasFragmentCmd_noArgs(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+
 	fs := afero.NewMemMapFs()
 	cmd := cmd.PrHasFragmentCommand(fs)
 
@@ -27,6 +30,8 @@ func TestPrHasFragmentCmd_noArgs(t *testing.T) {
 }
 
 func TestPrHasFragmentCmd_oneArg(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+
 	settings.Init()
 
 	fs := afero.NewMemMapFs()
@@ -43,6 +48,8 @@ func TestPrHasFragmentCmd_oneArg(t *testing.T) {
 }
 
 func TestPrHasFragmentCmd_oneArgFailCase(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+
 	settings.Init()
 
 	fs := afero.NewMemMapFs()

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -32,7 +32,9 @@ func Init() {
 	if err := viper.ReadInConfig(); err == nil {
 		log.Println("Using config file:", viper.ConfigFileUsed())
 	} else {
-		log.Fatalln(err)
+		// NOTE: we do not fail in this case as it's ok not to have the config file
+		// but we want to alert the user that the file has not been found
+		log.Println(err)
 	}
 }
 

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -5,7 +5,6 @@
 package settings
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"path"
@@ -31,9 +30,9 @@ func Init() {
 
 	// TODO: better error handling (skip missing file error)
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Println("Using config file:", viper.ConfigFileUsed())
+		log.Println("Using config file:", viper.ConfigFileUsed())
 	} else {
-		fmt.Println(err)
+		log.Fatalln(err)
 	}
 }
 


### PR DESCRIPTION
Small changes to `cmd` package tests to suppress log messages and avoid variable override discovered in #48

