### PR TITLE
Fragment template adjustments, typo fixes and log fragment path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ elastic-agent-changelog-tool
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.idea/

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,6 +1,6 @@
 # File based approach
 
-This CLI tool is file based. This means files are it's primary source and primary output, and all steps in the process produce files that can be archived or versioned (through `git` for example).
+This CLI tool is file based. This means files are its primary source and primary output, and all steps in the process produce files that can be archived or versioned (through `git` for example).
 
 Adopting a file based approach has this advantages:
 - Editing files is widely supported 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ Configurations are bound to environment variables with same name and `ELASTIC_AG
 This CLI supports and adhere to cross platform XDG Standard provided by [`OpenPeeDeeP/xdg`][xdg].
 
 |Settings key|Default value|Note|
-|---|---|---|---|
+|---|---|---|
 |`fragment_location`|`$GIT_REPO_ROOT/changelog/fragments`|The location of changelog fragments used by the CLI. By default `fragment_root` + `fragment_path`.| 
 |`fragment_path`|`changelog/fragments`|The path in `fragment_root` where to locate changelog fragments.|
 |`fragment_root`|`$GIT_REPO_ROOT`|The root folder for `fragment_location`.|

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,7 +2,7 @@
 
 ## Install from release binary
 
-Download latest release from the [Releases](https://github.com/elastic/elastic-agent-changelog-tool/releases/latest) page.
+Download the latest release from the [Releases](https://github.com/elastic/elastic-agent-changelog-tool/releases/latest) page.
 
 On macOS, use `xattr -r -d com.apple.quarantine elastic-agent-changelog-tool` after downloading to allow the binary to run.
 
@@ -28,3 +28,4 @@ $ make build
 ```
 
 `elastic-agent-changelog-tool` binary will be created in the root folder.
+Add it to your path.

--- a/internal/changelog/fragment/creator.go
+++ b/internal/changelog/fragment/creator.go
@@ -6,6 +6,7 @@ package fragment
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path"
 	"strings"
@@ -66,7 +67,13 @@ func (c FragmentCreator) Create(slug string) error {
 		return fmt.Errorf("cannot create fragment location folder: %v", err)
 	}
 
-	return afero.WriteFile(c.fs, path.Join(c.location, c.filename(slug)), data, fragmentPerm)
+	filePath := path.Join(c.location, c.filename(slug))
+	if err := afero.WriteFile(c.fs, filePath, data, fragmentPerm); err != nil {
+		return err
+	}
+
+	log.Print("created fragment ", filePath)
+	return nil
 }
 
 // sanitizeFilename takes care of removing dangerous elements from a string so it can be safely

--- a/internal/changelog/fragment/template.yaml
+++ b/internal/changelog/fragment/template.yaml
@@ -1,4 +1,4 @@
-# one of:
+# Kind can be one of:
 # - breaking-change: a change to previously-documented behavior
 # - deprecation: functionality that is being removed in a later release
 # - bug-fix: fixes a problem in a previous version
@@ -9,20 +9,27 @@
 # - upgrade: important information for someone upgrading from a prior version
 # - other: does not fit into any of the other categories
 kind: feature
+
 # Change summary; a 80ish characters long description of the change.
-summary: 
-# Long description; in case the summary is not enough to describe the change this field accomodate a description without length limits.
-# description: 
+summary:
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+#description:
+
 # Affected component; a word indicating the component this changeset affects.
 component:
+
 # PR number; optional; the PR number that added the changeset.
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-# pr: 1234
+#pr: 1234
+
 # Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.
-# issue: 1234
+#issue: 1234
+
 # Repository URL; optional; the repository URL related to this changeset and pr and issue numbers.
 # If not present is automatically filled by the tooling based on the repository this file has been committed in.
-# repository: https://github.com/elastic/elastic-agent-changelog-tool
+#repository: https://github.com/elastic/elastic-agent-changelog-tool


### PR DESCRIPTION
I was asked to test the tool, and I found a few things I believe could be improved. Mainly the fragment template, I had a hard time to find out all the fields there. I ended up mixing the commented out field and its documentation. 