### PR TITLE
Implement default renderer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa // indirect
 	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f // indirect
 	golang.org/x/sys v0.0.0-20211210111614-af8b64212486 // indirect
-	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/text v0.3.7
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect

--- a/internal/changelog/asciidoc-template.asciidoc
+++ b/internal/changelog/asciidoc-template.asciidoc
@@ -1,0 +1,86 @@
+// begin {{.Version}} relnotes
+
+[[release-notes-{{.Version}}]]
+== {{.Component}} {{.Version}}
+
+// TODO: support multiple components
+Review important information about the {{.Component}} {{.Version}} release.
+
+{{ if .Security -}}
+[discrete]
+[[security-updates-{{.Version}}]]
+=== Security updates
+
+{{.Component}}::{{ range $item := .Security }}
+* {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}
+{{- end }}
+{{- end }}
+{{ if .BreakingChange -}}
+[discrete]
+[[breaking-changes-{{.Version}}]]
+=== Breaking changes
+
+Breaking changes can prevent your application from optimal operation and
+performance. Before you upgrade, review the breaking changes, then mitigate the
+impact to your application.
+
+// TODO: add details and impact
+{{.Component}}::{{ range $item := .BreakingChange }}
+* {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}
+{{- end }}
+{{- end }}
+{{ if .KnownIssue -}}
+[discrete]
+[[known-issues-{{.Version}}]]
+=== Known issues
+
+// TODO: add details and impact
+{{.Component}}::{{ range $item := .KnownIssue }}
+* {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}
+{{- end }}
+{{- end }}
+{{ if .Deprecation -}}
+[discrete]
+[[deprecations-{{.Version}}]]
+=== Deprecations
+
+The following functionality is deprecated in {{.Version}}, and will be removed in
+{{.Version}}. Deprecated functionality does not have an immediate impact on your
+application, but we strongly recommend you make the necessary updates after you
+upgrade to {{.Version}}.
+
+{{.Component}}::{{ range $item := .Deprecation }}
+* {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}
+{{- end }}
+{{- end }}
+{{ if .Feature -}}
+[discrete]
+[[new-features-{{.Version}}]]
+=== New features
+
+The {{.Version}} release adds the following new and notable features.
+
+{{.Component}}::{{ range $item := .Feature }}
+* {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}
+{{- end }}
+{{- end }}
+{{ if .Enhancement }}
+[discrete]
+[[enhancements-{{.Version}}]]
+=== Enhancements
+
+{{.Component}}::{{ range $item := .Enhancement }}
+* {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}
+{{- end }}
+{{- end }}
+{{ if .BugFix }}
+[discrete]
+[[bug-fixes-{{.Version}}]]
+=== Bug fixes
+
+{{.Component}}::{{ range $item := .BugFix }}
+* {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}
+{{- end }}
+{{- end }}
+
+// end {{.Version}} relnotes

--- a/internal/changelog/entry.go
+++ b/internal/changelog/entry.go
@@ -12,22 +12,26 @@ type FragmentFileInfo struct {
 }
 
 type Entry struct {
-	Summary     string           `yaml:"summary"`
-	Description string           `yaml:"description"`
-	Kind        Kind             `yaml:"kind"`
-	LinkedPR    int              `yaml:"pr"`
-	LinkedIssue int              `yaml:"issue"`
-	Timestamp   int64            `yaml:"timestamp"`
-	File        FragmentFileInfo `yaml:"file"`
+	// fields from template
+	Kind        Kind   `yaml:"kind"`
+	Summary     string `yaml:"summary"`
+	Description string `yaml:"description"`
+	Component   string `yaml:"component" `
+	LinkedPR    int    `yaml:"pr"`
+	LinkedIssue int    `yaml:"issue"`
+
+	Timestamp int64            `yaml:"timestamp"`
+	File      FragmentFileInfo `yaml:"file"`
 }
 
 // EntriesFromFragment returns one or more entries based on the fragment File.
 // A single Fragment can contain multiple Changelog entries.
 func EntryFromFragment(f fragment.File) Entry {
 	e := Entry{
+		Kind:        kind2kind(f),
 		Summary:     f.Fragment.Summary,
 		Description: f.Fragment.Description,
-		Kind:        kind2kind(f),
+		Component:   f.Fragment.Component,
 		LinkedPR:    f.Fragment.Pr,
 		LinkedIssue: f.Fragment.Issue,
 		Timestamp:   f.Timestamp,

--- a/internal/changelog/file.go
+++ b/internal/changelog/file.go
@@ -1,0 +1,26 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package changelog
+
+import (
+	"fmt"
+
+	"github.com/spf13/afero"
+	"gopkg.in/yaml.v3"
+)
+
+func FromFile(fs afero.Fs, inFile string) (Changelog, error) {
+	b, err := afero.ReadFile(fs, inFile)
+	if err != nil {
+		return Changelog{}, fmt.Errorf("cannot read file: %s", inFile)
+	}
+
+	c := Changelog{}
+	if err := yaml.Unmarshal(b, &c); err != nil {
+		return Changelog{}, fmt.Errorf("cannot parse changelog YAML from file: %s", inFile)
+	}
+
+	return c, nil
+}

--- a/internal/changelog/renderer.go
+++ b/internal/changelog/renderer.go
@@ -1,0 +1,147 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package changelog
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"html/template"
+	"log"
+	"path"
+	"strings"
+
+	"github.com/spf13/afero"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+type Renderer struct {
+	changelog Changelog
+	fs        afero.Fs
+	// src is the source location to gather changelog fragments
+	src string
+	// dest is the destination location where the changelog is written to
+	dest string
+}
+
+func NewRenderer(fs afero.Fs, c Changelog, dest string) *Renderer {
+	return &Renderer{
+		changelog: c,
+		fs:        fs,
+		dest:      dest,
+	}
+}
+
+func (r Renderer) Render() error {
+	log.Printf("render changelog for version: %s\n", r.changelog.Version)
+
+	tpl, err := r.Template()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	type TemplateData struct {
+		Component string
+		Version   string
+		Changelog Changelog
+		Kinds     map[Kind]bool
+
+		BreakingChange []Entry
+		Deprecation    []Entry
+		BugFix         []Entry
+		Enhancement    []Entry
+		Feature        []Entry
+		KnownIssue     []Entry
+		Security       []Entry
+		Upgrade        []Entry
+		Other          []Entry
+	}
+	td := TemplateData{
+		"{agent}", r.changelog.Version, r.changelog,
+		collectKinds(r.changelog.Entries),
+		collectByKind(r.changelog.Entries, BreakingChange),
+		collectByKind(r.changelog.Entries, Deprecation),
+		collectByKind(r.changelog.Entries, BugFix),
+		collectByKind(r.changelog.Entries, Enhancement),
+		collectByKind(r.changelog.Entries, Feature),
+		collectByKind(r.changelog.Entries, KnownIssue),
+		collectByKind(r.changelog.Entries, Security),
+		collectByKind(r.changelog.Entries, Upgrade),
+		collectByKind(r.changelog.Entries, Other),
+	}
+
+	tmpl, err := template.New("asciidoc-release-notes").
+		Funcs(template.FuncMap{
+			"linkPRSource": func(component string, id int) string {
+				component = "agent"
+				return fmt.Sprintf("{%s-pull}%d[#%d]", component, id, id)
+			},
+			"linkIssueSource": func(component string, id int) string {
+				component = "agent"
+				return fmt.Sprintf("{%s-issue}%d[#%d]", component, id, id)
+			},
+			// Capitalize sentence and ensure ends with .
+			"beautify": func(s1 string) string {
+				s2 := strings.Builder{}
+				s2.WriteString(cases.Title(language.English).String(s1))
+				if !strings.HasSuffix(s1, ".") {
+					s2.WriteString(".")
+				}
+				return s2.String()
+			},
+		}).
+		Parse(string(tpl))
+	if err != nil {
+		panic(err)
+	}
+
+	var data bytes.Buffer
+
+	err = tmpl.Execute(&data, td)
+	if err != nil {
+		panic(err)
+	}
+
+	outFile := path.Join(r.dest, fmt.Sprintf("%s.asciidoc", r.changelog.Version))
+	log.Printf("saving changelog in %s\n", outFile)
+
+	return afero.WriteFile(r.fs, outFile, data.Bytes(), changelogFilePerm)
+}
+
+//go:embed asciidoc-template.asciidoc
+var asciidocTemplate embed.FS
+
+func (r Renderer) Template() ([]byte, error) {
+	data, err := asciidocTemplate.ReadFile("asciidoc-template.asciidoc")
+	if err != nil {
+		return []byte{}, fmt.Errorf("cannot read embedded template: %w", err)
+	}
+
+	return data, nil
+}
+
+func collectKinds(items []Entry) map[Kind]bool {
+	// NOTE: collect kinds in a set like map to avoid duplicates
+	kinds := map[Kind]bool{}
+
+	for _, e := range items {
+		kinds[e.Kind] = true
+	}
+
+	return kinds
+}
+
+func collectByKind(items []Entry, k Kind) []Entry {
+	entries := []Entry{}
+
+	for _, e := range items {
+		if e.Kind == k {
+			entries = append(entries, e)
+		}
+	}
+
+	return entries
+}

--- a/internal/changelog/renderer.go
+++ b/internal/changelog/renderer.go
@@ -21,8 +21,6 @@ import (
 type Renderer struct {
 	changelog Changelog
 	fs        afero.Fs
-	// src is the source location to gather changelog fragments
-	src string
 	// dest is the destination location where the changelog is written to
 	dest string
 }
@@ -75,12 +73,14 @@ func (r Renderer) Render() error {
 
 	tmpl, err := template.New("asciidoc-release-notes").
 		Funcs(template.FuncMap{
+			// nolint:staticcheck // ignoring for now, supports for multiple component is not implemented
 			"linkPRSource": func(component string, id int) string {
-				component = "agent"
+				component = "agent" // TODO: remove this when implementing support for multiple components
 				return fmt.Sprintf("{%s-pull}%d[#%d]", component, id, id)
 			},
+			// nolint:staticcheck // ignoring for now, supports for multiple component is not implemented
 			"linkIssueSource": func(component string, id int) string {
-				component = "agent"
+				component = "agent" // TODO: remove this when implementing support for multiple components
 				return fmt.Sprintf("{%s-issue}%d[#%d]", component, id, id)
 			},
 			// Capitalize sentence and ensure ends with .
@@ -124,7 +124,7 @@ func (r Renderer) Template() ([]byte, error) {
 }
 
 func collectKinds(items []Entry) map[Kind]bool {
-	// NOTE: collect kinds in a set like map to avoid duplicates
+	// NOTE: collect kinds in a set-like map to avoid duplicates
 	kinds := map[Kind]bool{}
 
 	for _, e := range items {

--- a/internal/changelog/renderer_internal_test.go
+++ b/internal/changelog/renderer_internal_test.go
@@ -1,0 +1,116 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package changelog
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_collectKinds(t *testing.T) {
+	type args struct {
+		items []Entry
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[Kind]bool
+	}{
+		{
+			"no kind",
+			args{[]Entry{}},
+			map[Kind]bool{},
+		},
+		{
+			"one kind",
+			args{[]Entry{
+				{Kind: Feature},
+			}},
+			map[Kind]bool{
+				Feature: true,
+			},
+		},
+		{
+			"more kinds",
+			args{[]Entry{
+				{Kind: Feature},
+				{Kind: BugFix},
+			}},
+			map[Kind]bool{
+				Feature: true,
+				BugFix:  true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := collectKinds(tt.args.items); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("collectKinds() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_collectByKind(t *testing.T) {
+	type args struct {
+		items []Entry
+		k     Kind
+	}
+	tests := []struct {
+		name string
+		args args
+		want []Entry
+	}{
+		{
+			"no entries",
+			args{
+				items: []Entry{
+					{Summary: "foobar", Kind: Feature},
+				},
+				k: BugFix,
+			},
+			[]Entry{},
+		},
+		{
+			"one entry",
+			args{
+				items: []Entry{
+					{Summary: "foobar", Kind: Feature},
+				},
+				k: Feature,
+			},
+			[]Entry{{Summary: "foobar", Kind: Feature}},
+		},
+		{
+			"multiple entry same kind",
+			args{
+				items: []Entry{
+					{Summary: "foobar", Kind: Feature},
+					{Summary: "foo", Kind: Feature},
+				},
+				k: Feature,
+			},
+			[]Entry{{Summary: "foobar", Kind: Feature}, {Summary: "foo", Kind: Feature}},
+		},
+		{
+			"multiple entry different kind",
+			args{
+				items: []Entry{
+					{Summary: "foobar", Kind: Feature},
+					{Summary: "foo", Kind: BugFix},
+				},
+				k: Feature,
+			},
+			[]Entry{{Summary: "foobar", Kind: Feature}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := collectByKind(tt.args.items, tt.args.k); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("collectByKind() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/changelog/renderer_test.go
+++ b/internal/changelog/renderer_test.go
@@ -1,0 +1,60 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package changelog_test
+
+import (
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/elastic/elastic-agent-changelog-tool/internal/changelog"
+	"github.com/spf13/afero"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderer(t *testing.T) {
+	fs := afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs())
+
+	viper.Set("changelog_destination", "testdata")
+
+	filename := "0.0.0.yaml"
+	src := "testdata"
+	dest := viper.GetString("changelog_destination")
+
+	t.Log("building changelog from test fragments")
+	builder := changelog.NewBuilder(fs, filename, "0.0.0", src, dest)
+	err := builder.Build()
+	require.NoError(t, err)
+
+	t.Log("loading generated changelog")
+	inFile := path.Join(src, filename)
+	c, err := changelog.FromFile(fs, inFile)
+	require.NoError(t, err)
+
+	r := changelog.NewRenderer(fs, c, dest)
+
+	err = r.Render()
+	require.Nil(t, err)
+
+	out, err := afero.ReadFile(fs, "testdata/0.0.0.asciidoc")
+	require.NoError(t, err)
+	t.Log(string(out))
+	require.NotEmpty(t, out)
+
+	for _, e := range c.Entries {
+		switch e.Kind {
+		// NOTE: this is the list of kinds of entries we expect to see
+		// in the rendered changelog (not all kinds are expected)
+		case changelog.BreakingChange, changelog.Deprecation,
+			changelog.BugFix, changelog.Enhancement,
+			changelog.Feature, changelog.KnownIssue,
+			changelog.Security:
+			require.Contains(t, strings.ToLower(string(out)), e.Summary)
+		default:
+			require.NotContains(t, strings.ToLower(string(out)), e.Summary)
+		}
+	}
+}


### PR DESCRIPTION
This PR provides the first implementation of the default changelog renderer.

The default renderer renders Asciidoc following the format of https://github.com/elastic/observability-docs/blob/5e2f16b351769a2d9ed7373d5e3290c16498eefa/docs/en/ingest-management/release-notes/release-notes-8.2.asciidoc


Closes #46
