### PR TITLE
Automate pr field collection

### DIFF
--- a/internal/changelog/builder.go
+++ b/internal/changelog/builder.go
@@ -86,15 +86,23 @@ func (b Builder) Build() error {
 	for i, entry := range b.changelog.Entries {
 		// Filling empty PR fields
 		if entry.LinkedPR[0] == 0 {
-			prID, err := fillEmptyPRField(entry.File.Name, c)
+			prIDs, err := fillEmptyPRField(entry.File.Name, c)
 			if err == nil {
-				b.changelog.Entries[i].LinkedPR = prID
+				b.changelog.Entries[i].LinkedPR = prIDs
+				if len(prIDs) > 1 {
+					log.Printf("delete de additional PRs in the changelog for %s", entry.File.Name)
+				}
+			} else {
+				log.Printf("fill the PR field in the changelog for %s", entry.File.Name)
 			}
 		} else {
 			// Applying heuristics to PR fields
 			originalPR, err := findOriginalPR(entry.LinkedPR[0], c)
 			if err == nil {
 				b.changelog.Entries[i].LinkedPR = []int{originalPR}
+			} else {
+				// This should only fail if the PR is mistyped in the fragment
+				log.Printf("check that the PR field is correct in the changelog for %s", entry.File.Name)
 			}
 		}
 	}

--- a/internal/changelog/entry.go
+++ b/internal/changelog/entry.go
@@ -15,7 +15,7 @@ type Entry struct {
 	Summary     string           `yaml:"summary"`
 	Description string           `yaml:"description"`
 	Kind        Kind             `yaml:"kind"`
-	LinkedPR    int              `yaml:"pr"`
+	LinkedPR    []int            `yaml:"pr"`
 	LinkedIssue int              `yaml:"issue"`
 	Timestamp   int64            `yaml:"timestamp"`
 	File        FragmentFileInfo `yaml:"file"`
@@ -28,7 +28,7 @@ func EntryFromFragment(f fragment.File) Entry {
 		Summary:     f.Fragment.Summary,
 		Description: f.Fragment.Description,
 		Kind:        kind2kind(f),
-		LinkedPR:    f.Fragment.Pr,
+		LinkedPR:    []int{f.Fragment.Pr},
 		LinkedIssue: f.Fragment.Issue,
 		Timestamp:   f.Timestamp,
 		File: FragmentFileInfo{

--- a/internal/github/interfaces.go
+++ b/internal/github/interfaces.go
@@ -20,6 +20,12 @@ type githubPullRequestsService interface {
 	) ([]*gh.PullRequest, *gh.Response, error)
 	// https://pkg.go.dev/github.com/google/go-github/v32/github#PullRequestsService.ListFiles
 	ListFiles(ctx context.Context, owner string, repo string, number int, opts *gh.ListOptions) ([]*gh.CommitFile, *gh.Response, error)
+	Get(
+		ctx context.Context,
+		owner string,
+		repo string,
+		number int,
+	) (*gh.PullRequest, *gh.Response, error)
 }
 
 type githubUsersService interface {


### PR DESCRIPTION
Closes #40 

This automates the PR field collection during the consolidation of the changelog.


Manual user editing in the `changelog.yaml` file is required in 2 cases:
- Multiple PRs found due to heuristics -> deleting the additional PR fields
- No PR found -> filling the PR field


Testing was done by manually adding various fragment files (including forcing the hash to correspond to an `elastic/beats` commit for an empty PR field) and checking the changelog. 

I don't see a better way of testing it right now. Do you have any suggestions here @endorama?