### PR TITLE
Add goreleaser release process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 elastic-agent-changelog-tool
+dist/*
 
 # Test binary, built with `go test -c`
 *.test
@@ -15,4 +16,6 @@ elastic-agent-changelog-tool
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+# IDEs
 .idea/
+.vscode

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,8 @@
+builds:
+  # this build supports reproducible builds (see docs)
+  - flags: [-trimpath]
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    ldflags:
+      - -X github.com/elastic/elastic-agent-changelog-tool/internal/version.CommitHash={{.ShortCommit}}
+      - -X github.com/elastic/elastic-agent-changelog-tool/internal/version.SourceDateEpoch={{.CommitDate}}
+      - -X github.com/elastic/elastic-agent-changelog-tool/internal/version.Tag={{.Tag}}

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ VERSION_LDFLAGS = -X $(VERSION_IMPORT_PATH).CommitHash=$(VERSION_COMMIT_HASH) -X
 
 .PHONY: build
 
+# NOTE: this command is only for dev builds, releases are build using goreleaser
 build:
 	go build -ldflags "$(VERSION_LDFLAGS)" -o elastic-agent-changelog-tool
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,40 @@
+# Release process
+
+This project uses [GoReleaser] to release a new version of the application.
+
+Release publishing is automatically managed by the Jenkins CI ([Jenkinsfile]) and it's triggered by Git tags. 
+
+Release artifacts are available in the [Releases] section. This project supports **reproducible builds**.
+
+## Creating a new release
+
+1. Fetch latest main from origin (remember to rebase the branch):
+
+        git fetch origin
+        git rebase origin/main
+
+2. Create Git tag with release candidate:
+
+        git tag v0.2.0 -m "Release version 0.2.0"
+
+3. Push new tag to the upstream.
+
+        git push origin v0.2.0 
+
+4. The CI will run a new job for the just pushed tag and publish released artifacts.
+
+## Reproducible builds
+
+This project supports [reproducible builds] (builds that always produce the exact same binary given the same sources).
+
+Support is achieved through:
+- `Makefile`: using [source epoch] instead of build datetime
+- `GoReleaser`(see [docs][gorel-docs]): using `trimpath`, `mod_timestamp` and `.CommitDate`
+
+
+[GoReleaser]: https://goreleaser.com/
+[Jenkinsfile]: https://github.com/elastic/elastic-agent-changelog-tool/blob/main/.ci/Jenkinsfile
+[Releases]: https://github.com/elastic/elastic-package/releases
+[reproducible builds]: https://reproducible-builds.org/
+[source epoch]: https://reproducible-builds.org/docs/source-date-epoch/
+[gorel-docs]: https://goreleaser.com/customization/build/#reproducible-builds


### PR DESCRIPTION
Part of #42

`elastic-package` leverages GoReleaser to build and release its versions.

This PR adds GoReleaser configuration to build binaries and create GitHub released based on Git tags.

It misses the CI automation.
