### PR TITLE
ci: automated releases

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     PIPELINE_LOG_LEVEL = 'INFO'
+    GITHUB_TOKEN_CREDENTIALS = "2a9602aa-ab9f-4e52-baf3-b71ca88469c7"
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -63,6 +64,20 @@ pipeline {
       post {
         always {
           junit(allowEmptyResults: true, keepLongStdio: true, testResults: '**/junit-report.xml')
+        }
+      }
+    }
+    stage('Release') {
+      when {
+        tag pattern: '\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
+      }
+      steps {
+        dir("${BASE_DIR}"){
+          withCredentials([string(credentialsId: "${env.GITHUB_TOKEN_CREDENTIALS}", variable: 'GITHUB_TOKEN')]) {
+            // Ensure that tags are present so goreleaser can build the changelog from the last release.
+            gitCmd(cmd: 'fetch', args: '--unshallow --tags')
+            sh(label: 'goreleaser', script: 'curl -sL https://git.io/goreleaser | bash')
+          }
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     PIPELINE_LOG_LEVEL = 'INFO'
     GITHUB_TOKEN_CREDENTIALS = "2a9602aa-ab9f-4e52-baf3-b71ca88469c7"
+    SLACK_CHANNEL = '#elastic-agent'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -68,9 +69,8 @@ pipeline {
       }
     }
     stage('Release') {
-      when {
-        tag pattern: '\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
-      }
+      options { skipDefaultCheckout() }
+      when { tag pattern: '\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP' }
       steps {
         dir("${BASE_DIR}"){
           withCredentials([string(credentialsId: "${env.GITHUB_TOKEN_CREDENTIALS}", variable: 'GITHUB_TOKEN')]) {
@@ -80,6 +80,14 @@ pipeline {
           }
         }
       }
+      post {
+        failure {
+          notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] Release *${env.TAG_NAME}* failed", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)")
+        }
+        success {
+          notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release *${env.TAG_NAME}* published", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)\nRepo URL: ${env.REPO_URL?.trim()}")
+        }
+      }
     }
   }
   post {
@@ -87,4 +95,13 @@ pipeline {
       notifyBuildResult(prComment: true)
     }
   }
+}
+
+def notifyStatus(def args = [:]) {
+  releaseNotification(slackChannel: "${env.SLACK_CHANNEL}",
+                      slackColor: args.slackStatus,
+                      slackCredentialsId: 'jenkins-slack-integration-token',
+                      to: "${env.NOTIFY_TO}",
+                      subject: args.subject,
+                      body: args.body)
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -73,10 +73,12 @@ pipeline {
       when { tag pattern: '\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP' }
       steps {
         dir("${BASE_DIR}"){
-          withCredentials([string(credentialsId: "${env.GITHUB_TOKEN_CREDENTIALS}", variable: 'GITHUB_TOKEN')]) {
-            // Ensure that tags are present so goreleaser can build the changelog from the last release.
-            gitCmd(cmd: 'fetch', args: '--unshallow --tags')
-            sh(label: 'goreleaser', script: 'curl -sL https://git.io/goreleaser | bash')
+          withGoEnv(){
+            withCredentials([string(credentialsId: "${env.GITHUB_TOKEN_CREDENTIALS}", variable: 'GITHUB_TOKEN')]) {
+              // Ensure that tags are present so goreleaser can build the changelog from the last release.
+              gitCmd(cmd: 'fetch', args: '--unshallow --tags')
+              sh(label: 'goreleaser', script: 'curl -sL https://git.io/goreleaser | bash')
+            }
           }
         }
       }


### PR DESCRIPTION
### What

Enable automated releases in GitHub when a git tag is created with the format `major.minor.patch`, i.e: `1.0.0`

Send an automated slack message when a release is out or something bad happened.

### Why

No manual releases

### Issue

Similar to https://github.com/elastic/elastic-package/pull/457

Requires https://github.com/elastic/elastic-agent-changelog-tool/pull/58
