### PR TITLE
Ignore non YAML file from fragment collection

### DIFF
--- a/internal/changelog/builder.go
+++ b/internal/changelog/builder.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/elastic/elastic-agent-changelog-tool/internal/changelog/fragment"
 	"github.com/spf13/afero"
@@ -78,7 +79,11 @@ func (b Builder) Build() error {
 
 func collectFragment(fs afero.Fs, path string, info os.FileInfo, err error, files *[]string) error {
 	if info, err := fs.Stat(path); err == nil && !info.IsDir() {
-		*files = append(*files, path)
+		if filepath.Ext(path) == ".yaml" {
+			*files = append(*files, path)
+		} else {
+			log.Printf("skipping %s (not a YAML file)", path)
+		}
 	} else {
 		return err
 	}

--- a/internal/changelog/builder.go
+++ b/internal/changelog/builder.go
@@ -45,13 +45,7 @@ func (b Builder) Build() error {
 
 	var files []string
 	err := afero.Walk(b.fs, b.src, func(path string, info os.FileInfo, err error) error {
-		if info, err := b.fs.Stat(path); err == nil && !info.IsDir() {
-			files = append(files, path)
-		} else {
-			return err
-		}
-
-		return nil
+		return collectFragment(b.fs, path, info, err, &files)
 	})
 	if err != nil {
 		return fmt.Errorf("cannot walk path %s: %w", b.src, err)
@@ -80,4 +74,14 @@ func (b Builder) Build() error {
 	outFile := path.Join(b.dest, b.filename)
 	log.Printf("saving changelog in %s\n", outFile)
 	return afero.WriteFile(b.fs, outFile, data, changelogFilePerm)
+}
+
+func collectFragment(fs afero.Fs, path string, info os.FileInfo, err error, files *[]string) error {
+	if info, err := fs.Stat(path); err == nil && !info.IsDir() {
+		*files = append(*files, path)
+	} else {
+		return err
+	}
+
+	return nil
 }

--- a/internal/changelog/builder_internal_test.go
+++ b/internal/changelog/builder_internal_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package changelog
 
 import (

--- a/internal/changelog/builder_internal_test.go
+++ b/internal/changelog/builder_internal_test.go
@@ -1,0 +1,34 @@
+package changelog
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_collectFragment(t *testing.T) {
+	testFs := afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs())
+
+	var files []string
+	err := afero.Walk(testFs, "testdata", func(path string, info os.FileInfo, err error) error {
+		return collectFragment(testFs, path, info, err, &files)
+	})
+
+	require.NoError(t, err)
+
+	log.Println(files)
+	require.Contains(t, files, "testdata/.gitkeep")
+	require.Contains(t, files, "testdata/1648040928-breaking-change.yaml")
+	require.Contains(t, files, "testdata/1648040928-bug-fix.yaml")
+	require.Contains(t, files, "testdata/1648040928-deprecation.yaml")
+	require.Contains(t, files, "testdata/1648040928-enhancement.yaml")
+	require.Contains(t, files, "testdata/1648040928-feature.yaml")
+	require.Contains(t, files, "testdata/1648040928-known-issue.yaml")
+	require.Contains(t, files, "testdata/1648040928-other.yaml")
+	require.Contains(t, files, "testdata/1648040928-security.yaml")
+	require.Contains(t, files, "testdata/1648040928-unknown.yaml")
+	require.Contains(t, files, "testdata/1648040928-upgrade.yaml")
+}

--- a/internal/changelog/builder_internal_test.go
+++ b/internal/changelog/builder_internal_test.go
@@ -20,7 +20,7 @@ func Test_collectFragment(t *testing.T) {
 	require.NoError(t, err)
 
 	log.Println(files)
-	require.Contains(t, files, "testdata/.gitkeep")
+	require.NotContains(t, files, "testdata/.gitkeep")
 	require.Contains(t, files, "testdata/1648040928-breaking-change.yaml")
 	require.Contains(t, files, "testdata/1648040928-bug-fix.yaml")
 	require.Contains(t, files, "testdata/1648040928-deprecation.yaml")

--- a/internal/changelog/builder_test.go
+++ b/internal/changelog/builder_test.go
@@ -1,0 +1,29 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package changelog_test
+
+import (
+	"testing"
+
+	"github.com/elastic/elastic-agent-changelog-tool/internal/changelog"
+	"github.com/spf13/afero"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuilder_Build(t *testing.T) {
+	fs := afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs())
+	viper.Set("fragment_location", "testdata")
+
+	b := changelog.NewBuilder(fs, "filename", "0.0.0", "testdata", "testdata")
+
+	err := b.Build()
+	require.NoError(t, err)
+
+	// FIXME: built changelog is not inspectable as b.changelog is not updated &
+	// there is no way to access it anyway
+	// fmt.Println(b.Changelog())
+	// require.Len(t, b.Changelog().Entries, 10)
+}


### PR DESCRIPTION
In https://github.com/elastic/elastic-agent-changelog-tool/commit/cb365b667def5e7018305074a82cfddb43091a36 @LucianPy discovered that the FS walker collecting fragments in `changelog.Build` funcition was collecting also the `.gitkeep` file, and thus broke when trying to parse it.

This PR extracts the walker function, add tests to it and add an exclusion filter based on file extension: it collects only files with `.yaml` extension.

