### PR TITLE
Automate issue fragment field collection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/OpenPeeDeeP/xdg v1.0.0
 	github.com/google/go-github/v32 v32.1.0
+	github.com/shurcooL/githubv4 v0.0.0-20220520033151-0b4e3294ff00
 	github.com/spf13/afero v1.8.1
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.1
@@ -12,6 +13,8 @@ require (
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
+
+require github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 // indirect
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -30,8 +33,8 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa // indirect
-	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f // indirect
-	golang.org/x/sys v0.0.0-20211210111614-af8b64212486 // indirect
+	golang.org/x/net v0.0.0-20220728211354-c7608f3a8462 // indirect
+	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
 	golang.org/x/text v0.3.7
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -371,6 +371,10 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
 github.com/sagikazarmark/crypt v0.4.0/go.mod h1:ALv2SRj7GxYV4HO9elxH9nS6M9gW+xDNxqmyJ6RfDFM=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/shurcooL/githubv4 v0.0.0-20220520033151-0b4e3294ff00 h1:fiFvD4lT0aWjuuAb64LlZ/67v87m+Kc9Qsu5cMFNK0w=
+github.com/shurcooL/githubv4 v0.0.0-20220520033151-0b4e3294ff00/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
+github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 h1:B1PEwpArrNp4dkQrfxh/abbBAOZBVp0ds+fBEOUOqOc=
+github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29/go.mod h1:AuYgA5Kyo4c7HfUmvRGs/6rGlMMV/6B1bVnB9JxJEEg=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
@@ -536,8 +540,8 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1/go.mod h1:9tjilg8BloeKEkVJvy7fQ90B1CfIiPueXVOjqfkSzI8=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f h1:OfiFi4JbukWwe3lzw+xunroH1mnC1e2Gy5cxNJApiSY=
-golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220728211354-c7608f3a8462 h1:UreQrH7DbFXSi9ZFox6FNT3WBooWmdANpU+IfkT1T4I=
+golang.org/x/net v0.0.0-20220728211354-c7608f3a8462/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -644,9 +648,11 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211210111614-af8b64212486 h1:5hpz5aRr+W1erYCL5JRhSUBJRph7l9XkNveoExlrKYk=
 golang.org/x/sys v0.0.0-20211210111614-af8b64212486/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdpZ4kha7wBWZrbVKCIZg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/changelog/builder.go
+++ b/internal/changelog/builder.go
@@ -126,6 +126,9 @@ func (b Builder) Build(owner, repo string) error {
 				}
 
 				linkedIssues = append(linkedIssues, tempIssues...)
+				if len(linkedIssues) > 1 {
+					log.Printf("multiple issues found for %s, please remove all but one of them", entry.File.Name)
+				}
 			}
 
 			b.changelog.Entries[i].LinkedIssue = linkedIssues

--- a/internal/changelog/builder_test.go
+++ b/internal/changelog/builder_test.go
@@ -5,6 +5,7 @@
 package changelog_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/elastic/elastic-agent-changelog-tool/internal/changelog"
@@ -52,4 +53,17 @@ func TestFillEmptyPRFieldBadHash(t *testing.T) {
 	prIDs, err := changelog.FillEmptyPRField("123", "elastic", "beats", c)
 	require.Error(t, err)
 	require.Empty(t, prIDs)
+}
+
+func TestFindIssues(t *testing.T) {
+	r, hc := githubtest.GetHttpClient(t)
+	defer r.Stop() //nolint:errcheck
+
+	graphqlClient := github.NewGraphQLClient(hc)
+
+	issues, err := changelog.FindIssues(graphqlClient, context.Background(), "elastic", "beats", 32501, 50)
+	require.NoError(t, err)
+	require.NotEmpty(t, issues)
+	require.Len(t, issues, 1)
+	require.ElementsMatch(t, issues, []int{32483})
 }

--- a/internal/changelog/entry.go
+++ b/internal/changelog/entry.go
@@ -17,7 +17,7 @@ type Entry struct {
 	Description string `yaml:"description"`
 	Component   string `yaml:"component" `
 	LinkedPR    []int  `yaml:"pr"`
-	LinkedIssue int    `yaml:"issue"`
+	LinkedIssue []int  `yaml:"issue"`
 
 	Timestamp int64            `yaml:"timestamp"`
 	File      FragmentFileInfo `yaml:"file"`
@@ -32,7 +32,7 @@ func EntryFromFragment(f fragment.File) Entry {
 		Description: f.Fragment.Description,
 		Component:   f.Fragment.Component,
 		LinkedPR:    []int{},
-		LinkedIssue: f.Fragment.Issue,
+		LinkedIssue: []int{},
 		Timestamp:   f.Timestamp,
 		File: FragmentFileInfo{
 			Name:     f.Name,
@@ -42,6 +42,10 @@ func EntryFromFragment(f fragment.File) Entry {
 
 	if f.Fragment.Pr > 0 {
 		e.LinkedPR = []int{f.Fragment.Pr}
+	}
+
+	if f.Fragment.Issue > 0 {
+		e.LinkedIssue = []int{f.Fragment.Issue}
 	}
 
 	return e

--- a/internal/changelog/renderer.go
+++ b/internal/changelog/renderer.go
@@ -86,9 +86,15 @@ func (r Renderer) Render() error {
 				return strings.Join(res, " ")
 			},
 			// nolint:staticcheck // ignoring for now, supports for multiple component is not implemented
-			"linkIssueSource": func(component string, id int) string {
+			"linkIssueSource": func(component string, ids []int) string {
 				component = "agent" // TODO: remove this when implementing support for multiple components
-				return fmt.Sprintf("{%s-issue}%d[#%d]", component, id, id)
+				res := make([]string, len(ids))
+
+				for i, id := range ids {
+					res[i] = fmt.Sprintf("{%s-issue}%v[#%v]", component, id, id)
+				}
+
+				return strings.Join(res, " ")
 			},
 			// Capitalize sentence and ensure ends with .
 			"beautify": func(s1 string) string {

--- a/internal/changelog/testdata/fixtures/TestFindIssues.yaml
+++ b/internal/changelog/testdata/fixtures/TestFindIssues.yaml
@@ -1,0 +1,65 @@
+---
+version: 1
+interactions:
+- request:
+    body: |
+      {"query":"query($issuesLen:Int!$owner:String!$prID:Int!$repo:String!){repository(owner: $owner, name: $repo){pullRequest(number: $prID){closingIssuesReferences (first: $issuesLen){edges{node{number}}}}}}","variables":{"issuesLen":50,"owner":"elastic","prID":32501,"repo":"beats"}}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"repository":{"pullRequest":{"closingIssuesReferences":{"edges":[{"node":{"number":32483}}]}}}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 29 Jul 2022 14:32:44 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; format=json
+      X-Github-Request-Id:
+      - B671:9BC3:921A81:96B8D2:62E3EF8B
+      X-Oauth-Scopes:
+      - admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
+        admin:repo_hook, delete:packages, delete_repo, gist, notifications, project,
+        repo, user, workflow, write:discussion, write:packages
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4998"
+      X-Ratelimit-Reset:
+      - "1659108224"
+      X-Ratelimit-Resource:
+      - graphql
+      X-Ratelimit-Used:
+      - "2"
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -5,14 +5,21 @@
 package github
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 
 	gh "github.com/google/go-github/v32/github"
+	"github.com/shurcooL/githubv4"
 )
 
 type Client struct {
 	PullRequests githubPullRequestsService
 	Users        githubUsersService
+}
+
+type ClientGraphQL struct {
+	PR githubGraphQLPRService
 }
 
 func NewClient(httpClient *http.Client) *Client {
@@ -22,4 +29,54 @@ func NewClient(httpClient *http.Client) *Client {
 		PullRequests: client.PullRequests,
 		Users:        client.Users,
 	}
+}
+
+func NewGraphQLClient(c *http.Client) *ClientGraphQL {
+	client := githubv4.NewClient(c)
+
+	s := &graphqlService{client: client}
+
+	return &ClientGraphQL{
+		PR: s,
+	}
+}
+
+type graphqlService struct {
+	client *githubv4.Client
+}
+
+func (s *graphqlService) FindIssues(ctx context.Context, owner, repo string, prID, issuesLen int) ([]int, error) {
+	variables := map[string]interface{}{
+		"issuesLen": githubv4.Int(issuesLen),
+		"prID":      githubv4.Int(prID),
+		"owner":     githubv4.String(owner),
+		"repo":      githubv4.String(repo),
+	}
+
+	var q struct {
+		Repository struct {
+			PullRequest struct {
+				ClosingIssuesReferences struct {
+					Edges []struct {
+						Node struct {
+							Number int64
+						}
+					}
+				} `graphql:"closingIssuesReferences (first: $issuesLen)"`
+			} `graphql:"pullRequest(number: $prID)"`
+		} `graphql:"repository(owner: $owner, name: $repo)"`
+	}
+
+	err := s.client.Query(ctx, &q, variables)
+	if err != nil {
+		return nil, fmt.Errorf("graphql mutate: %w", err)
+	}
+
+	issues := make([]int, len(q.Repository.PullRequest.ClosingIssuesReferences.Edges))
+
+	for i, e := range q.Repository.PullRequest.ClosingIssuesReferences.Edges {
+		issues[i] = int(e.Node.Number)
+	}
+
+	return issues, nil
 }

--- a/internal/github/interfaces.go
+++ b/internal/github/interfaces.go
@@ -29,3 +29,7 @@ type githubUsersService interface {
 	// https://pkg.go.dev/github.com/google/go-github/v32/github#UsersService.Get
 	Get(ctx context.Context, user string) (*gh.User, *gh.Response, error)
 }
+
+type githubGraphQLPRService interface {
+	FindIssues(ctx context.Context, owner, repo string, prID, issuesLen int) ([]int, error)
+}


### PR DESCRIPTION
Closes #41 

REST does not provide a way to get linked issues so `githubv4` had to be used as a dependency here to extract the data using GraphQL.

Because of this, at some point, all REST code has to be changed to GraphQL for maintenance reasons.
 

***To be discussed what to do in case of multiple issues from the user's perspective.