### PR TITLE
Add asciidoc changelog to fragments script

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45
+          version: v1.48
 
   license:
     runs-on: ubuntu-latest

--- a/tools/CHANGELOG.next.asciidoc
+++ b/tools/CHANGELOG.next.asciidoc
@@ -1,0 +1,32 @@
+// Use these for links to issue and pulls. Note issues and pulls redirect one to
+// each other on Github, so don't worry too much on using the right prefix.
+:issue-beats: https://github.com/elastic/beats/issues/
+:pull-beats: https://github.com/elastic/beats/pull/
+
+:issue: https://github.com/elastic/elastic-agent/issues/
+:pull: https://github.com/elastic/elastic-agent/pull/
+
+=== Elastic Agent version HEAD
+
+==== Breaking changes
+
+- Docker container is not run as root by default. {pull-beats}[21213]
+- Read Fleet connection information from `fleet.*` instead of `fleet.kibana.*`. {pull-beats}[24713]
+
+==== Bugfixes
+
+- diagnostics collect log names are fixed on Windows machines, command will ignore failures. AgentID is included in diagnostics(and diagnostics collect) output. {issue}81[81] {issue}92[92] {issue}190[190] {pull}262[262]
+- Allow the / char in variable names in eql and transpiler. {issue}715[715] {pull}718[718]
+- Fix data duplication for standalone agent on Kubernetes using the default manifest {issue-beats}31512[31512] {pull}742[742]
+- Agent updates will clean up unneeded artifacts. {issue}693[693] {issue}694[694] {pull}752[752]
+
+==== New features
+
+- Allow pprof endpoints for elastic-agent or beats if enabled. {pull-beats}[28983] {pull-beats}[29155]
+- Set `agent.id` to the Fleet Agent ID in events published from inputs backed by Beats. {issue-beats}[21121] {pull-beats}[26394] {pull-beats}[26548]
+- Agent now adapts the beats queue size based on output settings. {issue-beats}[26638] {pull-beats}[27429]
+- Support ephemeral containers in Kubernetes dynamic provider. {issue-beats}[#27020] {pull-beats}[27707]
+- Add support for enabling the metrics buffer endpoint in the elastic-agent and beats it runs. diagnostics collect command will gather metrics-buffer data if enabled. {pull-beats}[30471]
+- Changed the default policy selection logic. When the agent has no policy id or name defined, it will fall back to defaults (defined by $FLEET_SERVER_POLICY_ID and $FLEET_DEFAULT_TOKEN_POLICY_NAME environment variables respectively). {issue-beats}[29774] {pull}226[226]
+- Support scheduled actions and cancellation of pending actions. {issue}393[393] {pull}419[419]
+- Bump node.js version for heartbeat/synthetics to 16.15.0

--- a/tools/asciidoc_to_fragments.py
+++ b/tools/asciidoc_to_fragments.py
@@ -4,6 +4,7 @@
 
 import time
 import argparse
+from os import makedirs
 
 
 timestamp = round(time.time())
@@ -123,6 +124,11 @@ if __name__ == "__main__":
 
     if args.repo:
         default_repolink = repo_dict[args.repo]
+
+    try:
+        makedirs(fragments_path)
+    except FileExistsError as e:
+        pass
 
     with open(args.path, 'r') as f:
         iterate_lines(f)

--- a/tools/asciidoc_to_fragments.py
+++ b/tools/asciidoc_to_fragments.py
@@ -1,0 +1,128 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+
+import time
+import argparse
+
+
+timestamp = round(time.time())
+
+fragments_path = "changelog/fragments/"
+fragments_counter = 0
+
+repo_dict = {
+    "agent": "https://github.com/elastic/elastic-agent",
+    "beats": "https://github.com/elastic/beats"
+}
+default_repolink = "https://github.com/elastic/elastic-agent"
+
+kind_dict = {
+    "Breaking changes": "breaking-change",
+    "Bugfixes": "bug-fix",
+    "New features": "feature",
+}
+kind_token = "===="
+field_token = "-"
+
+
+def write_fragment(title, fragment_dict):
+    path = "".join([fragments_path,
+                    str(timestamp + fragments_counter),
+                    "-",
+                    title,
+                    ".yaml"])
+
+    with open(path, 'w+') as f:
+        for k, v in fragment_dict.items():
+            f.write(f"{k}: {v}\n")
+
+def parse_line(line, kind):
+    global fragments_counter
+    fragments_counter += 1
+
+    summary, *entries = line.split(" {")
+    if len(entries) == 0:
+        print(f"Warning: {line} has no PR/issue fields!\n")
+
+    fragment_dict = {"kind": kind}
+    fragment_dict["summary"] = summary.lstrip(field_token).strip()
+    fragment_dict["summary"] = fragment_dict["summary"].replace(":", "")
+
+    title = fragment_dict["summary"]
+    title = title.replace(" ", "-")
+    title = title.replace("/", "|")
+    title = title.rstrip(".")
+
+    repo_link = ""
+
+    for entry in entries:
+        number = entry[entry.find("[")+1:entry.find("]")]
+        number = ''.join(filter(lambda n: n.isdigit(), number))
+
+        if "pull" in entry:
+            fragment_field, default_repo_token = ["pr", "pull}"]
+        if "issue" in entry:
+            fragment_field, default_repo_token = ["issue", "issue}"]
+
+        if fragment_field in fragment_dict.keys():
+            print(f"Skipping {line} -> multiple PRs/issues found!\n")
+            return
+
+        fragment_dict[fragment_field] = number
+
+        if entry.startswith(default_repo_token):
+            if repo_link:
+                if repo_link != default_repolink:
+                    print(f"Skipping {line} -> multiple repositories found!\n")
+                    return
+            repo_link = default_repolink
+        else:
+            for repo in repo_dict.keys():
+                if repo in entry:
+                    if repo_link and repo_link != repo_dict[repo]:
+                        print(f"Skipping {line} -> multiple repositories found!\n")
+                        return
+                    repo_link = repo_dict[repo]
+
+    if repo_link:
+        fragment_dict["repository"] = repo_link
+
+    write_fragment(title, fragment_dict)
+
+
+def iterate_lines(f, kind='', skip=True):
+    line = next(f, None)
+    if line is None:
+        return
+
+    if line.startswith(kind_token):
+        iterate_lines(f, kind_dict[line.lstrip(kind_token).strip()], skip=False)
+
+    elif line.isspace():
+        iterate_lines(f, kind, skip)
+
+    elif line.startswith(field_token) and skip is False:
+        parse_line(line, kind)
+
+    else:
+        iterate_lines(f, kind, skip=True)
+
+    iterate_lines(f, kind, skip)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--path", help="Changelog file path", required=True)
+    parser.add_argument("--workdir", help="Working directory path")
+    parser.add_argument("--repo", help="Repository name")
+    args = parser.parse_args()
+
+    if args.workdir:
+        args.path = ''.join([args.workdir, '/', args.path])
+        fragments_path = ''.join([args.workdir, '/', fragments_path])
+
+    if args.repo:
+        default_repolink = repo_dict[args.repo]
+
+    with open(args.path, 'r') as f:
+        iterate_lines(f)

--- a/tools/asciidoc_to_fragments.py
+++ b/tools/asciidoc_to_fragments.py
@@ -130,5 +130,6 @@ if __name__ == "__main__":
     except FileExistsError as e:
         pass
 
+    print("Skipped entries should be manually created")
     with open(args.path, 'r') as f:
         iterate_lines(f)


### PR DESCRIPTION
Closes #67

Script that converts asciidoc changelog from `elastic-agent` repository to fragments.
It also includes a stripped down version of the `CHANGELOG.next.asciidoc` to easily test it.

This works fine for `CHANGELOG.next.asciidoc`.
One edge case to be fixed in `CHANGELOG.asciidoc` (malformed changelog file for pull 24128).

Planned future updates:
- [ ] Regex for parsing
- [ ] Refactor and lint
