### PR TITLE
Fix cmds short descriptions

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -17,8 +17,8 @@ import (
 func BuildCmd(fs afero.Fs) *cobra.Command {
 
 	buildCmd := &cobra.Command{
-		Use:  "build",
-		Long: "Create changelog from fragments",
+		Use:   "build",
+		Short: "Create changelog from fragments",
 		Args: func(cmd *cobra.Command, args []string) error {
 			return nil
 		},

--- a/cmd/find_pr.go
+++ b/cmd/find_pr.go
@@ -24,8 +24,9 @@ argument with commit hash is required
 
 func FindPRCommand(appFs afero.Fs) *cobra.Command {
 	findPRCommand := &cobra.Command{
-		Use:  "find-pr",
-		Long: findPRLongDescription,
+		Use:   "find-pr",
+		Short: "Find the original PR that included a commit",
+		Long:  findPRLongDescription,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errListPRCmdMissingCommitHash

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -18,8 +18,8 @@ var errNewCmdMissingArg = errors.New("new requires title argument")
 func NewCmd() *cobra.Command {
 
 	newCmd := &cobra.Command{
-		Use:  "new title",
-		Long: "Create a new changelog fragment",
+		Use:   "new title",
+		Short: "Create a new changelog fragment",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errNewCmdMissingArg

--- a/cmd/pr_has_fragment.go
+++ b/cmd/pr_has_fragment.go
@@ -20,8 +20,8 @@ var errPrCheckCmdMissingArg = errors.New("pr-has-fragment command requires pr nu
 
 func PrHasFragmentCommand(appFs afero.Fs) *cobra.Command {
 	prCheckCmd := &cobra.Command{
-		Use:  "pr-has-fragment <pr-number>",
-		Long: "Check changelog fragment presence in the given PR.",
+		Use:   "pr-has-fragment <pr-number>",
+		Short: "Check changelog fragment presence in the given PR.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errPrCheckCmdMissingArg

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -16,8 +16,9 @@ import (
 
 func RenderCmd(fs afero.Fs) *cobra.Command {
 	renderCmd := &cobra.Command{
-		Use:  "render",
-		Long: "Render a changelog in an asciidoc file",
+		Use:   "render",
+		Short: "Render a changelog in an asciidoc file",
+		Long:  "Render a changelog in an asciidoc file",
 		Args: func(cmd *cobra.Command, args []string) error {
 			return nil
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,7 @@ func RootCmd() *cobra.Command {
 
 	rootCmd := &cobra.Command{
 		Use:          "elastic-agent-changelog-tool",
-		Long:         "elastic-agent-changelog-tool - Command line tool used for managing the change log for Elastic Agent and related components, including Beats.",
+		Short:        "elastic-agent-changelog-tool - Command line tool used for managing the change log for Elastic Agent and related components, including Beats.",
 		SilenceUsage: true,
 	}
 


### PR DESCRIPTION
Most cmds did not have a short description (shown in `--help`)
