### PR TITLE
Add `render` cmd to CLI

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,11 +19,12 @@ func main() {
 
 	rootCmd := cmd.RootCmd()
 	rootCmd.AddCommand(cmd.BuildCmd(appFs))
+	rootCmd.AddCommand(cmd.CleanupCmd(appFs))
 	rootCmd.AddCommand(cmd.FindPRCommand(appFs))
 	rootCmd.AddCommand(cmd.NewCmd())
 	rootCmd.AddCommand(cmd.PrHasFragmentCommand(appFs))
+	rootCmd.AddCommand(cmd.RenderCmd(appFs))
 	rootCmd.AddCommand(cmd.VersionCmd())
-	rootCmd.AddCommand(cmd.CleanupCmd(appFs))
 
 	err := rootCmd.Execute()
 	if err != nil {


### PR DESCRIPTION
Command was implemented but not added to available commands, thus
unusable.
