### PR TITLE
Coherent changelog locations

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -33,7 +33,6 @@ func BuildCmd(fs afero.Fs) *cobra.Command {
 				return fmt.Errorf("owner flag malformed: %w", err)
 			}
 
-			filename := viper.GetString("changelog_filename")
 			src := viper.GetString("fragment_location")
 			dest := viper.GetString("changelog_destination")
 
@@ -42,6 +41,7 @@ func BuildCmd(fs afero.Fs) *cobra.Command {
 				return fmt.Errorf("error parsing flag 'version': %w", err)
 			}
 
+			filename := fmt.Sprintf("%s.yaml", version)
 			b := changelog.NewBuilder(fs, filename, version, src, dest)
 
 			if err := b.Build(owner, repo); err != nil {

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -48,7 +48,7 @@ func TestBuildCmd(t *testing.T) {
 	err = cmd.Execute()
 	require.Nil(t, err)
 
-	changelogFile := path.Join(viper.GetString("changelog_destination"), viper.GetString("changelog_filename"))
+	changelogFile := path.Join(viper.GetString("changelog_destination"), fmt.Sprintf("%s.yaml", expectedVersion))
 	content, err := afero.ReadFile(testFs, changelogFile)
 	require.Nil(t, err)
 

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -58,8 +58,8 @@ func setDefaults() {
 		os.ExpandEnv(viper.GetString("fragment_root")),
 		viper.GetString("fragment_path")))
 
-	viper.SetDefault("changelog_destination", ".")
-	viper.SetDefault("rendered_changelog_destination", ".")
+	viper.SetDefault("changelog_destination", "changelog")
+	viper.SetDefault("rendered_changelog_destination", "changelog")
 }
 
 func setConstants() {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -59,7 +59,6 @@ func setDefaults() {
 		viper.GetString("fragment_path")))
 
 	viper.SetDefault("changelog_destination", ".")
-	viper.SetDefault("changelog_filename", "changelog.yaml")
 	viper.SetDefault("rendered_changelog_destination", ".")
 }
 


### PR DESCRIPTION
This PR updates `build` command to- use a fixed consolidated changelog filename (instead of relying on a setting) with the same name as the version being consolidated. It also updates the destination folders for consolidated changelog and rendered changelog to `changelog`, to keep everything scoped as neither is a final product.
