### PR TITLE
Fix issue automation

### DIFF
--- a/changelog/fragments/1662383510-Fix-issue-automation.yaml
+++ b/changelog/fragments/1662383510-Fix-issue-automation.yaml
@@ -1,0 +1,35 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix issue automation
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: 1234
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: 1234
+
+# Repository URL; optional; the repository URL related to this changeset and pr and issue numbers.
+# If not present is automatically filled by the tooling based on the repository this file has been committed in.
+#repository: https://github.com/elastic/elastic-agent-changelog-tool

--- a/internal/changelog/builder.go
+++ b/internal/changelog/builder.go
@@ -117,10 +117,10 @@ func (b Builder) Build(owner, repo string) error {
 			b.changelog.Entries[i].LinkedPR = []int{originalPR}
 		}
 
-		if len(entry.LinkedIssue) == 0 && len(entry.LinkedPR) > 0 {
+		if len(entry.LinkedIssue) == 0 && len(b.changelog.Entries[i].LinkedPR) > 0 {
 			linkedIssues := []int{}
 
-			for _, pr := range entry.LinkedPR {
+			for _, pr := range b.changelog.Entries[i].LinkedPR {
 				tempIssues, err := FindIssues(graphqlClient, context.Background(), owner, repo, pr, 50)
 				if err != nil {
 					log.Printf("%s: could not find linked issues for pr: %s/pull/%d", entry.File.Name, entry.Repository, entry.LinkedPR)


### PR DESCRIPTION
Closes #85 

My mistake here, if the PR automation happens it's correct to actually check `b.changelog.Entries[i]` instead of `entry`.

Thanks @endorama for spotting this.