### PR TITLE
jjbb: use fleet-ci

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -4,7 +4,7 @@
 ##### GLOBAL METADATA
 
 - meta:
-    cluster: beats-ci
+    cluster: fleet-ci
 
 ##### JOB DEFAULTS
 

--- a/.ci/jobs/elastic-agent-changelog-tool-mbp.yml
+++ b/.ci/jobs/elastic-agent-changelog-tool-mbp.yml
@@ -12,7 +12,7 @@
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
           discover-tags: true
-          notification-context: 'beats-ci'
+          notification-context: 'fleet-ci'
           repo: elastic-agent-changelog-tool
           repo-owner: elastic
           credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
@@ -39,4 +39,4 @@
             timeout: 100
           timeout: '15'
           use-author: true
-          wipe-workspace: 'True'
+          wipe-workspace: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # elastic-agent-changelog-tool
 Tooling to manage the changelog for beats, Elastic Agent and Fleet Server
 
-[CI activity](https://beats-ci.elastic.co/blue/organizations/jenkins/elastic-agent-changelog-tool-mbp/activity)
+[CI activity](https://fleet-ci.elastic.co/blue/organizations/jenkins/elastic-agent-changelog-tool-mbp/activity)
 
 ## Requirements
 
@@ -14,7 +14,7 @@ Install following one of the methods provided in [docs/install.md].
 
 To get started look into [docs/getting-started.md]
 
-Look at [docs/usage.md] for detailed usage guidelines. 
+Look at [docs/usage.md] for detailed usage guidelines.
 
 Look into [docs/concepts.md] for overall concepts behind how it works and [docs/glossary.md] for details about terms used in this project.
 


### PR DESCRIPTION
## What is the problem this PR solves?

Use `fleet-ci`  to scale horizontally the CI.

## Why

In order to distribute the load and reduce a single point of failure,

## Actions

- [x] Create webhook to point to `fleet-ci`