### PR TITLE
Fix build logic

### DIFF
--- a/changelog/fragments/1663757086-Fix-build-logic-for-Github-API-calls.yaml
+++ b/changelog/fragments/1663757086-Fix-build-logic-for-Github-API-calls.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix build logic for Github API calls
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: 1234
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: 1234

--- a/internal/changelog/builder_test.go
+++ b/internal/changelog/builder_test.go
@@ -74,3 +74,9 @@ func TestExtractEventNumber(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, id, "99")
 }
+func TestExtractOwnerRepo(t *testing.T) {
+	owner, repo, err := changelog.ExtractOwnerRepo("https://github.com/elastic/beats/pull/20186")
+	require.NoError(t, err)
+	require.Equal(t, owner, "elastic")
+	require.Equal(t, repo, "beats")
+}


### PR DESCRIPTION
Closes #108 

@endorama discovered a bug following the transition to URLs for pr/issue fields:
Github API calls were still using the `owner` and `repo` flag.

Now the URL is parsed and the `owner` and `repo` extracted are passed further.

`url` library was used here since the `Path` field makes this less error prone. 
For example, parsing will work with or without the "https://" prefix. 


