### PR TITLE
handle missing failure case to URL extraction

### DIFF
--- a/changelog/fragments/1667229980-handle-missing-failure-case-to-URL-extraction.yaml
+++ b/changelog/fragments/1667229980-handle-missing-failure-case-to-URL-extraction.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: handle missing failure case to URL extraction
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: 1234
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: 1234

--- a/internal/changelog/builder.go
+++ b/internal/changelog/builder.go
@@ -192,6 +192,10 @@ func ExtractOwnerRepo(eventURL string) (string, string, error) {
 		return "", "", fmt.Errorf("can't get owner or repo")
 	}
 
+	if len(urlParts) < 3 {
+		return "", "", fmt.Errorf("parsed url (%s) does not have required parts", eventURL)
+	}
+
 	return urlParts[1], urlParts[2], nil
 }
 


### PR DESCRIPTION
The current code check to determine a valid URL didn't take into
account this particular case which resulted in a panic at runtime.
