### PR TITLE
release: provide docker images

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -89,6 +89,8 @@ pipeline {
       steps {
         dir("${BASE_DIR}"){
           goReleaser() {
+            // Ensure that tags are present so goreleaser can build the changelog from the last release.
+            gitCmd(cmd: 'fetch', args: '--unshallow --tags')
             sh(label: 'goreleaser', script: 'goreleaser release')
           }
         }
@@ -126,8 +128,6 @@ def goReleaser(Closure body) {
   withGoEnv() {
     sh(label: 'install goreleaser', script: 'go install github.com/goreleaser/goreleaser@v1.6.3')
     withCredentials([string(credentialsId: "${env.GITHUB_TOKEN_CREDENTIALS}", variable: 'GITHUB_TOKEN')]) {
-      // Ensure that tags are present so goreleaser can build the changelog from the last release.
-      gitCmd(cmd: 'fetch', args: '--unshallow --tags')
       body()
     }
   }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -71,21 +71,25 @@ pipeline {
         }
       }
     }
-    stage('Release') {
+    stage('Prepare') {
       options { skipDefaultCheckout() }
-      when { tag pattern: 'v\\d+\\.\\d+\\.\\d+.*', comparator: 'REGEXP' }
       steps {
         deleteDir()
         unstash 'source'
         dir("${BASE_DIR}"){
-          dockerLogin(secret: "${DOCKER_ELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
-          withGoEnv() {
-            sh(label: 'install goreleaser', script: 'go install github.com/goreleaser/goreleaser@v1.6.3')
-            withCredentials([string(credentialsId: "${env.GITHUB_TOKEN_CREDENTIALS}", variable: 'GITHUB_TOKEN')]) {
-              // Ensure that tags are present so goreleaser can build the changelog from the last release.
-              gitCmd(cmd: 'fetch', args: '--unshallow --tags')
-              sh(label: 'goreleaser', script: 'goreleaser release')
-            }
+          goReleaser() {
+            sh(label: 'goreleaser', script: 'goreleaser release --prepare')
+          }
+        }
+      }
+    }
+    stage('Release') {
+      options { skipDefaultCheckout() }
+      when { tag pattern: 'v\\d+\\.\\d+\\.\\d+.*', comparator: 'REGEXP' }
+      steps {
+        dir("${BASE_DIR}"){
+          goReleaser() {
+            sh(label: 'goreleaser', script: 'goreleaser release')
           }
         }
       }
@@ -114,4 +118,17 @@ def notifyStatus(def args = [:]) {
                       to: "${env.NOTIFY_TO}",
                       subject: args.subject,
                       body: args.body)
+}
+
+
+def goReleaser(Closure body) {
+	dockerLogin(secret: "${DOCKER_ELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
+  withGoEnv() {
+    sh(label: 'install goreleaser', script: 'go install github.com/goreleaser/goreleaser@v1.6.3')
+    withCredentials([string(credentialsId: "${env.GITHUB_TOKEN_CREDENTIALS}", variable: 'GITHUB_TOKEN')]) {
+      // Ensure that tags are present so goreleaser can build the changelog from the last release.
+      gitCmd(cmd: 'fetch', args: '--unshallow --tags')
+      body()
+    }
+  }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -71,15 +71,12 @@ pipeline {
         }
       }
     }
-    stage('Prepare') {
+    stage('Snapshot') {
       options { skipDefaultCheckout() }
+      when { not { tag pattern: '.*', comparator: 'REGEXP' } }
       steps {
-        deleteDir()
-        unstash 'source'
-        dir("${BASE_DIR}"){
-          goReleaser() {
-            sh(label: 'goreleaser', script: 'goreleaser release --prepare')
-          }
+        goReleaser() {
+          sh(label: 'goreleaser --snapshot', script: 'goreleaser release --snapshot')
         }
       }
     }
@@ -87,12 +84,10 @@ pipeline {
       options { skipDefaultCheckout() }
       when { tag pattern: 'v\\d+\\.\\d+\\.\\d+.*', comparator: 'REGEXP' }
       steps {
-        dir("${BASE_DIR}"){
-          goReleaser() {
-            // Ensure that tags are present so goreleaser can build the changelog from the last release.
-            gitCmd(cmd: 'fetch', args: '--unshallow --tags')
-            sh(label: 'goreleaser', script: 'goreleaser release')
-          }
+        goReleaser() {
+          // Ensure that tags are present so goreleaser can build the changelog from the last release.
+          gitCmd(cmd: 'fetch', args: '--unshallow --tags')
+          sh(label: 'goreleaser release', script: 'goreleaser release')
         }
       }
       post {
@@ -124,11 +119,15 @@ def notifyStatus(def args = [:]) {
 
 
 def goReleaser(Closure body) {
-	dockerLogin(secret: "${DOCKER_ELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
-  withGoEnv() {
-    sh(label: 'install goreleaser', script: 'go install github.com/goreleaser/goreleaser@v1.6.3')
-    withCredentials([string(credentialsId: "${env.GITHUB_TOKEN_CREDENTIALS}", variable: 'GITHUB_TOKEN')]) {
-      body()
+  deleteDir()
+  unstash 'source'
+  dir("${BASE_DIR}"){
+    dockerLogin(secret: "${DOCKER_ELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
+    withGoEnv() {
+      sh(label: 'install goreleaser', script: 'go install github.com/goreleaser/goreleaser@v1.6.3')
+      withCredentials([string(credentialsId: "${env.GITHUB_TOKEN_CREDENTIALS}", variable: 'GITHUB_TOKEN')]) {
+        body()
+      }
     }
   }
 }

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,3 +6,14 @@ builds:
       - -X github.com/elastic/elastic-agent-changelog-tool/internal/version.CommitHash={{.ShortCommit}}
       - -X github.com/elastic/elastic-agent-changelog-tool/internal/version.SourceDateEpoch={{.CommitDate}}
       - -X github.com/elastic/elastic-agent-changelog-tool/internal/version.Tag={{.Tag}}
+dockers:
+  - image_templates:
+    - "docker.elastic.co/observability-ci/{{.ProjectName}}"
+    - "docker.elastic.co/observability-ci/{{.ProjectName}}:{{ .Tag }}"
+    skip_push: true
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ dockers:
   - image_templates:
     - "docker.elastic.co/observability-ci/{{.ProjectName}}"
     - "docker.elastic.co/observability-ci/{{.ProjectName}}:{{ .Tag }}"
-    skip_push: true
+    skip_push: false
     build_flag_templates:
     - "--pull"
     - "--label=org.opencontainers.image.created={{.Date}}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM docker.io/library/alpine:3.15.6
+
+COPY elastic-agent-changelog-tool /usr/bin/elastic-agent-changelog-tool
+
+ENTRYPOINT ["/usr/bin/elastic-agent-changelog-tool"]


### PR DESCRIPTION
Support docker images.
Additionally, support go-releaser for PRs in the CI by using `--snapshots`, to avoid publishing anything, this should help us to detect breaking changes in the go-releaser before any release

Requires https://github.com/elastic/elastic-agent-changelog-tool/pull/122
