### PR TITLE
Render `feature` description

### DIFF
--- a/changelog/fragments/1678182005-Render-description-for-kind-feature.yaml
+++ b/changelog/fragments/1678182005-Render-description-for-kind-feature.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Render description for kind feature
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/assets/asciidoc-template.asciidoc
+++ b/internal/assets/asciidoc-template.asciidoc
@@ -91,6 +91,10 @@ The {{.Version}} release adds the following new and notable features.
 {{ $k | header2}}
 {{ range $item := $v }}
 * {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}
+{{- if $item.Description }}
++
+{{ $item.Description }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/internal/changelog/renderer_test.go
+++ b/internal/changelog/renderer_test.go
@@ -48,11 +48,11 @@ func TestRenderer(t *testing.T) {
 		switch e.Kind {
 		// NOTE: this is the list of kinds of entries we expect to see
 		// in the rendered changelog (not all kinds are expected)
-		case changelog.BreakingChange, changelog.KnownIssue:
+		case changelog.BreakingChange, changelog.Feature, changelog.KnownIssue:
 			require.Contains(t, strings.ToLower(string(out)), e.Summary)
 			require.Contains(t, string(out), e.Description)
 		case changelog.Deprecation, changelog.BugFix, changelog.Enhancement,
-			changelog.Feature, changelog.Security:
+			changelog.Security:
 			require.Contains(t, strings.ToLower(string(out)), e.Summary)
 		default:
 			require.NotContains(t, strings.ToLower(string(out)), e.Summary)


### PR DESCRIPTION
This PR adds rendering of `description` field for changelog fragments of kind `feature`.

Closes #133 
