### PR TITLE
Patch deprecated set-output command in CI

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: get go version
         run: |
           gv=$(cat .go-version)
-          echo "::set-output name=go::$gv"
+          echo "go=$gv" >> $GITHUB_OUTPUT
         id: version
 
       - name: install Go
@@ -34,7 +34,7 @@ jobs:
       - name: get go version
         run: |
           gv=$(cat .go-version)
-          echo "::set-output name=go::$gv"
+          echo "go=$gv" >> $GITHUB_OUTPUT
         id: version
 
       - name: install Go
@@ -55,7 +55,7 @@ jobs:
       - name: get go version
         run: |
           gv=$(cat .go-version)
-          echo "::set-output name=go::$gv"
+          echo "go=$gv" >> $GITHUB_OUTPUT
         id: version
 
       - name: install Go
@@ -77,7 +77,7 @@ jobs:
       - name: get go version
         run: |
           gv=$(cat .go-version)
-          echo "::set-output name=go::$gv"
+          echo "go=$gv" >> $GITHUB_OUTPUT
         id: version
 
       - name: install Go
@@ -100,7 +100,7 @@ jobs:
       - name: get go version
         run: |
           gv=$(cat .go-version)
-          echo "::set-output name=go::$gv"
+          echo "go=$gv" >> $GITHUB_OUTPUT
         id: version
 
       - name: install Go


### PR DESCRIPTION
GitHub deprecated set-output command, replacing it with an environment
variable approach.

See
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<!--

Please add a Changelog Fragment with elastic-agent-changelog-fragment new "title" or add "skip-changelog" label.

-->
