### PR TITLE
Increase the timeout for the lint task

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -68,6 +68,15 @@ jobs:
         with:
           version: v1.51.2
 
+          # Give the job more time to execute.
+          # Regarding `--whole-files`, the linter is supposed to support linting of changed a patch only but,
+          # for some reason, it's very unreliable this way - sometimes it does not report any or some
+          # issues without linting the whole files, so we have to use `--whole-files`
+          # which can lead to some frustration from developers who would like to
+          # fix a single line in an existing codebase and the linter would force them
+          # into fixing all linting issues in the whole file instead.
+          args: --timeout=30m --whole-files
+
   license:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This commit increases the timeout and changes the flag for the linter to scan the whole file, similar to how we do it in other repositories.

