### PR TITLE
[`new` sub-command] Default title to git branch name

### DIFF
--- a/changelog/fragments/1686835318-new-title-optional.yaml
+++ b/changelog/fragments/1686835318-new-title-optional.yaml
@@ -1,0 +1,35 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Default new fragment title to git branch name
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: >
+  New changelog fragments are often created while working inside a
+  git branch. This change makes the title argument to the `new` sub-command
+  optional, defaulting the title to the name of the current git branch.
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -46,7 +46,7 @@ func NewCmd() *cobra.Command {
 		},
 	}
 
-	newCmd.Flags().String("title", viper.GetString("title"), "The title for the changelog")
+	newCmd.Flags().String("title", "", "The title for the changelog")
 
 	return newCmd
 }


### PR DESCRIPTION
<!--

Please add a Changelog Fragment with elastic-agent-changelog-fragment new "title" or add "skip-changelog" label.

-->

New changelog fragments are often created while working inside a  git branch. This change makes the title argument to the `new` sub-command optional (via the optional `--title` flag), defaulting the title to the name of the current git branch.

## Example usage

### Without specifying a title

```
$ ./elastic-agent-changelog-tool new
2023/06/20 09:16:21 Using config file: /Users/shaunak/development/github/elastic-agent-changelog-tool/config.yaml
2023/06/20 09:16:21 created fragment /Users/shaunak/development/github/elastic-agent-changelog-tool/changelog/fragments/1687277781-new-title-optional.yaml

$ git symbolic-ref --short HEAD
new-title-optional
```

### Specifying a single-word title

```
$ ./elastic-agent-changelog-tool new single
2023/06/20 09:16:46 Using config file: /Users/shaunak/development/github/elastic-agent-changelog-tool/config.yaml
2023/06/20 09:16:46 created fragment /Users/shaunak/development/github/elastic-agent-changelog-tool/changelog/fragments/1687277806-single.yaml
```

### Specifying a multi-word title

```
$ ./elastic-agent-changelog-tool new more than a single word
2023/06/20 09:17:02 Using config file: /Users/shaunak/development/github/elastic-agent-changelog-tool/config.yaml
2023/06/20 09:17:02 created fragment /Users/shaunak/development/github/elastic-agent-changelog-tool/changelog/fragments/1687277822-more-than-a-single-word.yaml
```