### PR TITLE
Remove single quote from file names

### DIFF
--- a/changelog/fragments/1695368036-remove-single-quote-from-file-names.yaml
+++ b/changelog/fragments/1695368036-remove-single-quote-from-file-names.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Remove single quote from file names
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/changelog/fragment/creator.go
+++ b/internal/changelog/fragment/creator.go
@@ -84,5 +84,6 @@ func sanitizeFilename(s string) string {
 	s = strings.Replace(s, "/", "-", -1)
 	s = strings.Replace(s, "\\", "-", -1)
 	s = strings.Replace(s, ":", "", -1)
+	s = strings.Replace(s, "'", "", -1)
 	return s
 }

--- a/internal/changelog/fragment/creator_internal_test.go
+++ b/internal/changelog/fragment/creator_internal_test.go
@@ -54,6 +54,7 @@ func TestSanitizeFilename(t *testing.T) {
 		{input: "foo\\bar", want: "foo-bar"},
 		{input: "foo bar/foobar\\", want: "foo-bar-foobar-"},
 		{input: "foo bar: foobar", want: "foo-bar-foobar"},
+		{input: "foo bar' foobar", want: "foo-bar-foobar"},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
<!--

Please add a Changelog Fragment with elastic-agent-changelog-fragment new "title" or add "skip-changelog" label.

-->

Single quotes breaks go get thus they need to be removed from fragments file names.

Close https://github.com/elastic/elastic-agent-changelog-tool/issues/162