### PR TITLE
[work in progress] Update release notes for the Markdown era

### DIFF
--- a/cmd/render.go
+++ b/cmd/render.go
@@ -35,6 +35,7 @@ func RenderCmd(fs afero.Fs) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dest := viper.GetString("changelog_destination")
 			renderedDest := viper.GetString("rendered_changelog_destination")
+			repo := viper.GetString("repo")
 
 			version, err := cmd.Flags().GetString("version")
 			if err != nil {
@@ -51,7 +52,7 @@ func RenderCmd(fs afero.Fs) *cobra.Command {
 				return fmt.Errorf("error loading changelog from file: %w", err)
 			}
 
-			r := changelog.NewRenderer(fs, c, renderedDest, template)
+			r := changelog.NewRenderer(fs, c, renderedDest, template, repo)
 
 			if err := r.Render(); err != nil {
 				return fmt.Errorf("cannot build asciidoc file: %w", err)

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,12 @@
 owner: elastic
 repo: elastic-agent-changelog-tool
-template: asciidoc-embedded
-components: [elastic-agent-changelog-tool]
+template:
+  - asciidoc-embedded
+  - markdown-breaking-template
+  - markdown-deprecations-template
+  - markdown-index-template
+  - markdown-known-issues-template
+components:
+  - beats
+  - elastic-agent
+  - fleet-server

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -14,12 +14,28 @@ import (
 // These strings can be used in the config template field or renderer template flag
 func GetEmbeddedTemplates() embeddedTemplates {
 	return map[string]string{
-		"asciidoc-embedded": "asciidoc-template.asciidoc",
+		"asciidoc-embedded":     "asciidoc-template.asciidoc",
+		"markdown-index":        "markdown-index-template.md",
+		"markdown-breaking":     "markdown-breaking-template.md",
+		"markdown-deprecations": "markdown-deprecations-template.md",
+		"markdown-known-issues": "markdown-known-issues-template.md",
 	}
 }
 
 //go:embed asciidoc-template.asciidoc
 var AsciidocTemplate embed.FS
+
+//go:embed markdown-index-template.md
+var MarkdownIndexTemplate embed.FS
+
+//go:embed markdown-breaking-template.md
+var MarkdownBreakingTemplate embed.FS
+
+//go:embed markdown-deprecations-template.md
+var MarkdownDeprecationsTemplate embed.FS
+
+//go:embed markdown-known-issues-template.md
+var MarkdownKnownIssuesTemplate embed.FS
 
 type embeddedTemplates map[string]string
 

--- a/internal/assets/markdown-breaking-template.md
+++ b/internal/assets/markdown-breaking-template.md
@@ -1,5 +1,4 @@
 ## {{.Version}} [{{.Repo}}-{{.Version}}-breaking-changes]
-
 {{ if .BreakingChange -}}{{ range $k, $v := .BreakingChange }}{{ range $item := $v }}
 ::::{dropdown} {{ $item.Summary | beautify }}
 {{ if $item.Description }}{{ $item.Description }}{{ end }}
@@ -10,4 +9,6 @@ For more information, check {{ linkPRSource $item.Component $item.LinkedPR }}{{ 
 
 {{ if not $item.Action }}% {{ end }}**Action**<br>{{ if $item.Action }}{{ $item.Action }}{{ else }}_Add a description of the what action to take_{{ end }}
 ::::
-{{- end }}{{- end }}{{- end }}
+{{- end }}{{- end }}{{ else }}
+_No breaking changes._
+{{- end }}

--- a/internal/assets/markdown-breaking-template.md
+++ b/internal/assets/markdown-breaking-template.md
@@ -1,0 +1,13 @@
+## {{.Version}} [{{.Repo}}-{{.Version}}-breaking-changes]
+
+{{ if .BreakingChange -}}{{ range $k, $v := .BreakingChange }}{{ range $item := $v }}
+::::{dropdown} {{ $item.Summary | beautify }}
+{{ if $item.Description }}{{ $item.Description }}{{ end }}
+
+For more information, check {{ linkPRSource $item.Component $item.LinkedPR }}{{ linkIssueSource $item.Component $item.LinkedIssue }}.
+
+{{ if not $item.Impact }}% {{ end }}**Impact**<br>{{ if $item.Impact }}{{ $item.Impact }}{{ else }}_Add a description of the impact_{{ end }}
+
+{{ if not $item.Action }}% {{ end }}**Action**<br>{{ if $item.Action }}{{ $item.Action }}{{ else }}_Add a description of the what action to take_{{ end }}
+::::
+{{- end }}{{- end }}{{- end }}

--- a/internal/assets/markdown-deprecations-template.md
+++ b/internal/assets/markdown-deprecations-template.md
@@ -1,0 +1,15 @@
+## {{.Version}} [{{.Repo}}-{{.Version}}-deprecations]
+{{ if .Deprecation -}}{{ range $k, $v := .Deprecation }}{{ range $item := $v }}
+
+::::{dropdown} {{ $item.Summary | beautify }}
+{{ if $item.Description }}{{ $item.Description }}{{ end }}
+
+For more information, check {{ linkPRSource $item.Component $item.LinkedPR }}{{ linkIssueSource $item.Component $item.LinkedIssue }}.
+
+{{ if not $item.Impact }}% {{ end }}**Impact**<br>{{ if $item.Impact }}{{ $item.Impact }}{{ else }}_Add a description of the impact_{{ end }}
+
+{{ if not $item.Action }}% {{ end }}**Action**<br>{{ if $item.Action }}{{ $item.Action }}{{ else }}_Add a description of the what action to take_{{ end }}
+::::
+{{- end }}{{- end }}
+{{ else }}_No deprecations._
+{{- end }}

--- a/internal/assets/markdown-deprecations-template.md
+++ b/internal/assets/markdown-deprecations-template.md
@@ -11,5 +11,6 @@ For more information, check {{ linkPRSource $item.Component $item.LinkedPR }}{{ 
 {{ if not $item.Action }}% {{ end }}**Action**<br>{{ if $item.Action }}{{ $item.Action }}{{ else }}_Add a description of the what action to take_{{ end }}
 ::::
 {{- end }}{{- end }}
-{{ else }}_No deprecations._
+{{ else }}
+_No deprecations._
 {{- end }}

--- a/internal/assets/markdown-index-template.md
+++ b/internal/assets/markdown-index-template.md
@@ -1,0 +1,19 @@
+## {{.Version}} [{{.Repo}}-release-notes-{{.Version}}]
+
+{{ if or .Feature .Enhancement }}
+### Features and enhancements [{{.Repo}}-{{.Version}}-features-enhancements]
+{{ if .Feature }}{{ range $k, $v := .Feature }}{{ range $item := $v }}
+* {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}
+{{- end }}{{- end }}{{- end }}{{ if .Enhancement }}{{ range $k, $v := .Enhancement }}{{ range $item := $v }}
+* {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}
+{{- end }}{{- end }}{{- end }}
+{{- end }}
+
+{{ if or .Security .BugFix }}
+### Fixes [{{.Repo}}-{{.Version}}-fixes]
+{{ if .Security }}{{ range $k, $v := .Security }}{{ range $item := $v }}
+* {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}
+{{- end }}{{- end }}{{- end }}{{ if .BugFix }}{{ range $k, $v := .BugFix }}{{ range $item := $v }}
+* {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}
+{{- end }}{{- end }}{{- end }}
+{{- end }}

--- a/internal/assets/markdown-index-template.md
+++ b/internal/assets/markdown-index-template.md
@@ -1,19 +1,29 @@
 ## {{.Version}} [{{.Repo}}-release-notes-{{.Version}}]
-
+{{ if or .Feature .Enhancement .Security .BugFix }}
 {{ if or .Feature .Enhancement }}
 ### Features and enhancements [{{.Repo}}-{{.Version}}-features-enhancements]
 {{ if .Feature }}{{ range $k, $v := .Feature }}{{ range $item := $v }}
-* {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}
+* {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}{{ if $item.Description }}
+{{ $item.Description | indent }}
+{{- end }}
 {{- end }}{{- end }}{{- end }}{{ if .Enhancement }}{{ range $k, $v := .Enhancement }}{{ range $item := $v }}
-* {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}
+* {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}{{ if $item.Description }}
+{{ $item.Description | indent }}
+{{- end }}
 {{- end }}{{- end }}{{- end }}
 {{- end }}
 
 {{ if or .Security .BugFix }}
 ### Fixes [{{.Repo}}-{{.Version}}-fixes]
 {{ if .Security }}{{ range $k, $v := .Security }}{{ range $item := $v }}
-* {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}
+* {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}{{ if $item.Description }}
+{{ $item.Description | indent }}
+{{- end }}
 {{- end }}{{- end }}{{- end }}{{ if .BugFix }}{{ range $k, $v := .BugFix }}{{ range $item := $v }}
-* {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}
-{{- end }}{{- end }}{{- end }}
+* {{ $item.Summary | beautify }} {{ linkPRSource $item.Component $item.LinkedPR }} {{ linkIssueSource $item.Component $item.LinkedIssue }}{{ if $item.Description }}
+{{ $item.Description | indent }}
+{{- end }}
+{{- end }}{{- end }}{{- end }}{{- end }}
+{{ else }}
+_No new features, enhancements, or fixes._
 {{- end }}

--- a/internal/assets/markdown-known-issues-template.md
+++ b/internal/assets/markdown-known-issues-template.md
@@ -1,0 +1,14 @@
+{{ if .KnownIssue -}}{{ range $k, $v := .KnownIssue }}{{ range $item := $v }}
+
+::::{dropdown} {{ $item.Summary | beautify }}
+**Applies to**: {{.Version}}
+
+{{ if $item.Description }}{{ $item.Description }}{{ end }}
+
+For more information, check {{ linkPRSource $item.Component $item.LinkedPR }}{{ linkIssueSource $item.Component $item.LinkedIssue }}.
+
+{{ if not $item.Impact }}% {{ end }}**Impact**<br>{{ if $item.Impact }}{{ $item.Impact }}{{ else }}_Add a description of the impact_{{ end }}
+
+{{ if not $item.Action }}% {{ end }}**Action**<br>{{ if $item.Action }}{{ $item.Action }}{{ else }}_Add a description of the what action to take_{{ end }}
+::::
+{{- end }}{{- end }}{{- end }}

--- a/internal/changelog/entry.go
+++ b/internal/changelog/entry.go
@@ -20,6 +20,9 @@ type Entry struct {
 	Component   string   `yaml:"component"`
 	LinkedPR    []string `yaml:"pr"`
 	LinkedIssue []string `yaml:"issue"`
+	Impact      string   `yaml:"impact"`
+	Action      string   `yaml:"action"`
+	Workaround  string   `yaml:"workaround"`
 
 	Timestamp int64            `yaml:"timestamp"`
 	File      FragmentFileInfo `yaml:"file"`
@@ -35,6 +38,9 @@ func EntryFromFragment(f fragment.File) Entry {
 		Component:   f.Fragment.Component,
 		LinkedPR:    []string{},
 		LinkedIssue: []string{},
+		Impact:      f.Fragment.Impact,
+		Action:      f.Fragment.Action,
+		Workaround:  f.Fragment.Workaround,
 		Timestamp:   f.Timestamp,
 		File: FragmentFileInfo{
 			Name:     f.Name,

--- a/internal/changelog/fragment/fragment.go
+++ b/internal/changelog/fragment/fragment.go
@@ -11,4 +11,7 @@ type Fragment struct {
 	Component   string `yaml:"component"`
 	Pr          string `yaml:"pr"`
 	Issue       string `yaml:"issue"`
+	Impact      string `yaml:"impact"`
+	Action      string `yaml:"action"`
+	Workaround  string `yaml:"workaround"`
 }

--- a/internal/changelog/fragment/template.yaml
+++ b/internal/changelog/fragment/template.yaml
@@ -1,3 +1,4 @@
+# REQUIRED
 # Kind can be one of:
 # - breaking-change: a change to previously-documented behavior
 # - deprecation: functionality that is being removed in a later release
@@ -10,23 +11,35 @@
 # - other: does not fit into any of the other categories
 kind: feature
 
+# REQUIRED for all kinds
 # Change summary; a 80ish characters long description of the change.
 summary: {{.Summary}}
 
+# REQUIRED for breaking-change, deprecation, known-issue
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.
-# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
-#description:
+# description:
 
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
 component:
 
-# PR URL; optional; the PR number that added the changeset.
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-#pr: https://github.com/owner/repo/1234
+# pr: https://github.com/owner/repo/1234
 
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.
-#issue: https://github.com/owner/repo/1234
+# issue: https://github.com/owner/repo/1234

--- a/internal/changelog/renderer.go
+++ b/internal/changelog/renderer.go
@@ -53,19 +53,27 @@ func (r Renderer) Render() error {
 		Changelog Changelog
 		Kinds     map[Kind]bool
 
+		// In Markdown, this goes to release notes
+		Enhancement map[string][]Entry
+		Feature     map[string][]Entry
+		Security    map[string][]Entry
+		BugFix      map[string][]Entry
+		// In Markdown, this goes to breaking changes
 		BreakingChange map[string][]Entry
-		Deprecation    map[string][]Entry
-		BugFix         map[string][]Entry
-		Enhancement    map[string][]Entry
-		Feature        map[string][]Entry
-		KnownIssue     map[string][]Entry
-		Security       map[string][]Entry
-		Upgrade        map[string][]Entry
-		Other          map[string][]Entry
+		// In Markdown, this goes to deprecations
+		Deprecation map[string][]Entry
+		// In Markdown, this goes to known issues
+		KnownIssue map[string][]Entry
+		// In Markdown... TBD
+		Upgrade map[string][]Entry
+		Other   map[string][]Entry
 	}
 
 	td := TemplateData{
-		buildTitleByComponents(r.changelog.Entries), r.changelog.Version, r.repo, r.changelog,
+		buildTitleByComponents(r.changelog.Entries),
+		r.changelog.Version,
+		r.repo,
+		r.changelog,
 		collectKinds(r.changelog.Entries),
 		// In Markdown, this goes to release notes
 		collectByKindMap(r.changelog.Entries, Enhancement),
@@ -114,6 +122,11 @@ func (r Renderer) Render() error {
 					s += "."
 				}
 				return s
+			},
+			// Indent lines
+			"indent": func(s string) string {
+				re := regexp.MustCompile(`\n|\r|^`)
+				return re.ReplaceAllString(s, "\n  ")
 			},
 			// Ensure components have section styling
 			"header2": func(s1 string) string {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -59,7 +59,7 @@ func setDefaults() {
 		viper.GetString("fragment_path")))
 
 	viper.SetDefault("changelog_destination", "changelog")
-	viper.SetDefault("rendered_changelog_destination", "changelog")
+	// viper.SetDefault("rendered_changelog_destination", "changelog")
 
 	viper.SetDefault("template", "asciidoc-embedded")
 }

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -25,7 +25,7 @@ func Init() {
 	setConstants()
 
 	viper.AddConfigPath(viper.GetString("config_file"))
-	viper.SetConfigName("config")
+	viper.SetConfigName("config.changelog.yaml")
 	viper.SetConfigType("yaml")
 
 	// TODO: better error handling (skip missing file error)


### PR DESCRIPTION
⚠️  THIS IS NOT READY FOR REVIEW  ⚠️ 

Adds the ability to generate Markdown files for release notes, breaking changes, and deprecations in the new format used on <https://www.elastic.co/docs/release-notes/fleet>.

More details to come...