### PR TITLE
ci: fix release

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,6 +63,8 @@ steps:
     key: release
     command:
       - ".buildkite/scripts/release.sh"
+    plugins:
+      - elastic/vault-github-token#v0.1.0:
     agents:
       provider: "gcp"
     depends_on:


### PR DESCRIPTION
Release requires a GitHub token, let's use https://github.com/elastic/vault-github-token-buildkite-plugin/

Let's wait for the terrazzo configuration