### PR TITLE
Handle releases with no changes

### DIFF
--- a/changelog/fragments/1761929110-handle-empty-changelogs.yaml
+++ b/changelog/fragments/1761929110-handle-empty-changelogs.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Handle releases with no changes.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: If there are no changes included in the release — in other words, there are no changelog fragment files — the changelog YAML file will still be generated, but the entries will be an empty array. This helps clarify that the release didn't have any notable changes rather than the release notes are missing.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component:
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent-changelog-tool/pull/222
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -108,8 +108,6 @@ The side effect is that the changelog will include all entries from latest stabl
 
 ## I'm the release manager
 
-> NOTE: This instructions are for the 0.2.0 milestone (when ready). As more features and automation is added the process will become simpler.
-
 ### Preparing the changelog
 
 These steps require [GitHub Authentication](./github-authentication.md).
@@ -126,9 +124,13 @@ These steps require [GitHub Authentication](./github-authentication.md).
 
     * `x.y.z` is the version to release.
     * `owner` is the user / organization the repository to use belongs to. The default value is `elastic`.
-    * `repo` is the name of the repository containing the issues / PRs, etc. The default value is `elastic-agent`.
+    * `repo` is the name of the repository containing the issues and PRs. The default value is `elastic-agent`.
+
+    >NOTE: If the repo you're targeting has an `owner` and `repo` defined in a `config.changelog.yaml` file, you do not need to specify them when running the command.
 
     This will create `./changelog/x.y.z.yaml`.
+
+    >NOTE: If there are no changes included in the release (there are no changelog fragment files), the changelog file will be generated with an empty array of entries.
 1. From the root of the repository run:
     ```
     $ elastic-agent-changelog-tool cleanup
@@ -140,6 +142,7 @@ These steps require [GitHub Authentication](./github-authentication.md).
     ```
 
     >IMPORTANT: Use `file_type` `markdown` for 9.x versions and `asciidoc` for 8.x versions.
+    >If the repo you're targeting has a `file_type` defined in a `config.changelog.yaml` file, you do not need to specify it when running the command.
 
     The files that are generated depend on the specified `file_type`. The destination directory depends on the `rendered_changelog_destination` defined in the the repo's `config.changelog.yaml`. If no `rendered_changelog_destination` is specified, it will be added to the `changelog` directory.
 


### PR DESCRIPTION
Handles releases with no changes. If there are no changes included in the release — in other words, there are no changelog fragment files — the changelog YAML file will still be generated, but the entries will be an empty array. This helps clarify that the release didn't have any notable changes rather than the release notes are missing.

cc @karenzone @ebeahan @pierrehilbert 