### PR TITLE
Add centralized `generate-release-notes` workflow

### DIFF
--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -66,5 +66,5 @@ jobs:
             ## Checklist
 
             - [ ] @${{ inputs.release_manager }} review this PR to make sure the correct items are included
-            - [ ] @elastic/ingest-docs-team review the language
+            - [ ] @elastic/ingest-docs review the language
             - [ ] @${{ inputs.release_manager }} merge on release day


### PR DESCRIPTION
Adds centralized `generate-release-notes` workflow that can then be used in elastic-agent, fleet-server, and beats. 

@v1v can you take a look at this PR? I tested this in my elastic-agent fork using [`.github/workflows/release-notes.yml`](https://github.com/colleenmcginnis/elastic-agent/blob/main/.github/workflows/release-notes.yml) and it did create https://github.com/colleenmcginnis/elastic-agent/pull/6. 🎉 