### PR TITLE
Fix YAML syntax in `make-checklist` step

### DIFF
--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -81,7 +81,7 @@ jobs:
             - [ ] @${{ inputs.release_manager }} review this PR to make sure the correct items are included
             - [ ] @elastic/ingest-docs review the language
             - [ ] @elastic/ingest-docs open a PR in the ingest-docs repo combining the Elastic Agent and Fleet Server release notes targeting the `${{ steps.get-minor.outputs.result }}` branch
-        - [ ] @${{ inputs.release_manager }} merge or close on release day. No forward or backports are needed.
+            - [ ] @${{ inputs.release_manager }} merge or close on release day. No forward or backports are needed.
             * Note: Release notes for 8.x versions are published from the ingest-docs repo. Merging this PR won't hurt, but it is unnecessary.
 
             - [ ] @elastic/ingest-docs merge PR in the ingest-docs repo. No forward or backports are needed.
@@ -93,7 +93,7 @@ jobs:
           BEATS_EA_FLEET_9: |
             - [ ] @${{ inputs.release_manager }} review this PR to make sure the correct items are included
             - [ ] @elastic/ingest-docs review the language
-        - [ ] @${{ inputs.release_manager }} merge this PR and forwardports on release day
+            - [ ] @${{ inputs.release_manager }} merge this PR and forwardports on release day
             * Note: In this repo, we publish from the ${{ inputs.branching_model }} branch. The changes in this PR will not be available on the docs site until they are added to the ${{ inputs.branching_model }} branch.
                 * Note: In this repo, we publish from the ${{ inputs.branching_model }} branch. The changes in this PR will not be available on the docs site until they are added to the ${{ inputs.branching_model }} branch.
       - name: Open PR


### PR DESCRIPTION
Fix YAML syntax in `make-checklist` step in `generate-release-notes` workflow.

Example of current failure: https://github.com/elastic/beats/actions/runs/21290352995.