### PR TITLE
Migrate to using `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -52,7 +52,7 @@ jobs:
           ./bin/elastic-agent-changelog-tool render --version "${VERSION}"
         env:
           VERSION: ${{ inputs.version }}
-          GITHUB_TOKEN: ${{ steps.fetch-ephemeral-token.outputs.token }}
+          GITHUB_TOKEN: ${{ env.GH_TOKEN }}
       - name: Get minor
         id: get-minor
         uses: actions/github-script@v8
@@ -99,7 +99,7 @@ jobs:
       - name: Open PR
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e #v7.0.8
         with:
-          token: ${{ steps.fetch-ephemeral-token.outputs.token }}
+          token: ${{ env.GH_TOKEN }}
           commit-message: add the ${{ inputs.version }} ${{ inputs.product }} release notes
           branch: release-notes-${{ inputs.version }}
           base: ${{ steps.get-minor.outputs.result }}


### PR DESCRIPTION
Recent changes to the `fetch-github-token` action requires migrating to using `env.GITHUB_TOKEN` over extracting from the output. The `generate-release-notes` action was only affected once we bumped the `fetch-github-token` version in https://github.com/elastic/elastic-agent-changelog-tool/pull/235.