### PR TITLE
Revert gnereate actions changes

### DIFF
--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -52,7 +52,7 @@ jobs:
           ./bin/elastic-agent-changelog-tool render --version "${VERSION}"
         env:
           VERSION: ${{ inputs.version }}
-          GITHUB_TOKEN: ${{ env.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.fetch-ephemeral-token.outputs.token }}
       - name: Get minor
         id: get-minor
         uses: actions/github-script@v8
@@ -99,7 +99,7 @@ jobs:
       - name: Open PR
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e #v7.0.8
         with:
-          token: ${{ env.GH_TOKEN }}
+          token: ${{ steps.fetch-ephemeral-token.outputs.token }}
           commit-message: add the ${{ inputs.version }} ${{ inputs.product }} release notes
           branch: release-notes-${{ inputs.version }}
           base: ${{ steps.get-minor.outputs.result }}

--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -41,7 +41,7 @@ jobs:
           ref: ${{ inputs.bc_commit_sha }}
       - name: Fetch ephemeral GitHub token
         id: fetch-ephemeral-token
-        uses: elastic/ci-gh-actions/fetch-github-token@v1.5.3
+        uses: elastic/ci-gh-actions/fetch-github-token@v1.0.0
         with:
           vault-instance: "ci-prod"
       - name: Generate release notes


### PR DESCRIPTION
Reverts two sets of changes:

* https://github.com/elastic/elastic-agent-changelog-tool/pull/235
* https://github.com/elastic/elastic-agent-changelog-tool/pull/236

These changes are breaking the release notes GitHub action for Beats, Elastic Agent and Fleet Server. Examples of failed runs: https://github.com/elastic/beats/actions/runs/28050227531/job/83038620439

I'm confident we just are missing a necessary change to support the version jump between `fetch-github-token` v1.0.0 and v1.5.3. However, this is blocking generating release notes for the three Streams projects and the quickest path to unblock is reverting.

I'll file an issue in the backlog to investigate what changes are necessary for future releases.