### PR TITLE
chore: upgrade fetch-github-token to v1.5.3

### DIFF
--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -41,7 +41,7 @@ jobs:
           ref: ${{ inputs.bc_commit_sha }}
       - name: Fetch ephemeral GitHub token
         id: fetch-ephemeral-token
-        uses: elastic/ci-gh-actions/fetch-github-token@v1.0.0
+        uses: elastic/ci-gh-actions/fetch-github-token@v1.5.3
         with:
           vault-instance: "ci-prod"
       - name: Generate release notes


### PR DESCRIPTION
## Repeat of https://github.com/elastic/elastic-agent-changelog-tool/pull/235

## Summary

Upgrades `elastic/ci-gh-actions/fetch-github-token` to `v1.5.3` across all affected workflow files.

## Reason

Version `v1.5.3` includes a fix for a security concern related to new GitHub token formats. Previous pinned versions (including commit SHAs and older semver tags) do not handle the updated token format correctly.

See: https://github.com/elastic/ci-gh-actions/releases/tag/v1.5.3

## Changes

Bumps `fetch-github-token` references from older versions/SHAs to `v1.5.3`.

---
